### PR TITLE
feat: parsed the environment variables

### DIFF
--- a/includes/libft.h
+++ b/includes/libft.h
@@ -1,3 +1,15 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   libft.h                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/13 15:29:04 by mdanish           #+#    #+#             */
+/*   Updated: 2024/05/13 15:29:05 by mdanish          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #ifndef LIBFT_H
 # define LIBFT_H
 
@@ -6,20 +18,20 @@
 # include <unistd.h>
 # include <stdbool.h>
 
-int		ft_printarr(char **tab);
-char	**ft_split(char const *s, char c);
-size_t	ft_strlen(const char *str);
-char	*ft_substr(char const *s, unsigned int start, size_t len);
-int		ft_strncmp(const char *s1, const char *s2, size_t n);
-char	*ft_strjoin(char const *s1, char const *s2);
-void	ft_strcpy(char *dest, char const *src);
-char	*ft_join(char **tab);
-__attribute__((pure)) char	*ft_strchr(const char *s, int c);
-void	ft_free_2d_arr(char **arr);
-char	*ft_strdup(const char *src);
-size_t	ft_strlcpy(char *dst, const char *src, size_t dstsize);
 char	*ft_char_strjoin(char const *s1, char const *s2, char const c);
+void	ft_free_2d_arr(char **arr);
 char	ft_is_quotation(char c, char quote);
 bool	ft_isspace(char c);
+char	*ft_join(char **tab);
+int		ft_printarr(char **tab);
+char	**ft_split(char const *s, char c);
+char	*ft_strchr(const char *s, int c);
+void	ft_strcpy(char *dest, char const *src);
+char	*ft_strdup(const char *src);
+char	*ft_strjoin(char const *s1, char const *s2);
+size_t	ft_strlcpy(char *dst, const char *src, size_t dstsize);
+size_t	ft_strlen(const char *str);
+int		ft_strncmp(const char *s1, const char *s2, size_t n);
+char	*ft_substr(char const *s, unsigned int start, size_t len);
 
 #endif

--- a/includes/libft.h
+++ b/includes/libft.h
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/13 15:29:04 by mdanish           #+#    #+#             */
-/*   Updated: 2024/05/13 15:29:05 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/13 18:59:10 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,7 @@ void	ft_free_2d_arr(char **arr);
 char	ft_is_quotation(char c, char quote);
 bool	ft_isspace(char c);
 char	*ft_join(char **tab);
+void	*ft_memset(void *array, int character, size_t bytes);
 int		ft_printarr(char **tab);
 char	**ft_split(char const *s, char c);
 char	*ft_strchr(const char *s, int c);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: maabdull <maabdull@student.42abudhabi.ae>  +#+  +:+       +#+        */
+/*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 17:24:25 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/06 19:15:16 by maabdull         ###   ########.fr       */
+/*   Updated: 2024/05/13 15:29:56 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,7 +35,7 @@
 # include <unistd.h>
 
 /** STRUCTURES **/
-enum		e_token_types
+enum e_token_types
 {
 	PIPE,
 	LESS,
@@ -46,29 +46,29 @@ enum		e_token_types
 	ERR
 };
 
-enum		e_cmd_types
+enum e_cmd_types
 {
 	CMD_EXEC
 };
 
 typedef struct s_token
 {
-	int		type;
-	char	*content;
-}			t_token;
+	int			type;
+	char		*content;
+}				t_token;
 
 typedef struct s_prompt
 {
-	char	*previous;
-	char	*current;
-} t_prompt;
+	char		*previous;
+	char		*current;
+}				t_prompt;
 
 typedef struct s_minishell
 {
-	t_token	*tokens;
-	int		token_count;
+	t_token		*tokens;
+	int			token_count;
 	t_prompt	*prompt;
-}			t_minishell;
+}				t_minishell;
 
 /*
  * General command structure.
@@ -78,45 +78,39 @@ typedef struct s_minishell
  * */
 typedef struct s_cmd
 {
-	int		type;
-}			t_cmd;
+	int			type;
+}				t_cmd;
 
 typedef struct s_cmd_exec
 {
-	int		type;
-	char	**tokens;
-}			t_cmd_exec;
+	int			type;
+	char		**tokens;
+}				t_cmd_exec;
 
 /** GLOBAL VARIABLE **/
-extern int	g_status_code;
+extern int		g_status_code;
 
 /** FUNCTIONS **/
 // Parsing
-void		parse(t_minishell *minishell, char *line);
-t_cmd		*create_exec_cmd(t_minishell *minishell);
+t_cmd			*create_exec_cmd(t_minishell *minishell);
+void			parse(t_minishell *minishell, char *line);
 
 // Execution
-int			exec_cmd(char **cmd, char **env);
-void		exec_builtin(char **cmd);
-void		run_cmd(t_cmd *cmd, char **env);
+void			exec_builtin(char **cmd);
+int				exec_cmd(char **cmd, char **env);
+void			run_cmd(t_cmd *cmd, char **env);
 
 // Built-ins
-bool		is_builtin(char *str);
-void		echo(char **cmd);
-int			cd(char **cmd);
+int				cd(char **cmd);
+void			echo(char **cmd);
+bool			is_builtin(char *str);
 
 // Cleanup
-void		free_tokens(t_minishell *minishell);
-void		free_cmd(t_cmd *cmd);
+void			free_cmd(t_cmd *cmd);
+void			free_tokens(t_minishell *minishell);
 
 // General
-t_prompt	*init_prompt(void);
-void	update_prompt(t_prompt *prompt);
-
-#include <readline/readline.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <unistd.h>
-#include <sys/wait.h>
+t_prompt		*init_prompt(void);
+void			update_prompt(t_prompt *prompt);
 
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 17:24:25 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/13 15:29:56 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/13 18:59:37 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,6 +35,14 @@
 # include <unistd.h>
 
 /** STRUCTURES **/
+
+typedef struct s_cmd t_cmd;
+typedef struct s_cmd_exec t_cmd_exec;
+typedef struct s_env_node t_env_node;
+typedef struct s_minishell t_minishell;
+typedef struct s_prompt t_prompt;
+typedef struct s_token t_token;
+
 enum e_token_types
 {
 	PIPE,
@@ -51,24 +59,33 @@ enum e_cmd_types
 	CMD_EXEC
 };
 
-typedef struct s_token
+struct s_token
 {
 	int			type;
 	char		*content;
-}				t_token;
+};
 
-typedef struct s_prompt
+struct s_prompt
 {
 	char		*previous;
 	char		*current;
-}				t_prompt;
+};
 
-typedef struct s_minishell
+struct s_env_node
 {
-	t_token		*tokens;
+	char		*env_name;
+	char		*env_content;
+	bool		env_print;
+	t_env_node	*next;
+};
+
+struct s_minishell
+{
 	int			token_count;
+	t_token		*tokens;
 	t_prompt	*prompt;
-}				t_minishell;
+	t_env_node	*env_variables;
+};
 
 /*
  * General command structure.
@@ -76,16 +93,16 @@ typedef struct s_minishell
  * Every parse function returns this and can be casted to another cmd type
  * because they all share the type variable
  * */
-typedef struct s_cmd
+struct s_cmd
 {
 	int			type;
-}				t_cmd;
+};
 
-typedef struct s_cmd_exec
+struct s_cmd_exec
 {
 	int			type;
 	char		**tokens;
-}				t_cmd_exec;
+};
 
 /** GLOBAL VARIABLE **/
 extern int		g_status_code;
@@ -112,5 +129,8 @@ void			free_tokens(t_minishell *minishell);
 // General
 t_prompt		*init_prompt(void);
 void			update_prompt(t_prompt *prompt);
+
+// Miscellaneous
+void	ft_lstadd_back(t_env_node **list, t_env_node *new_node);
 
 #endif

--- a/sources/builtins/builtins.c
+++ b/sources/builtins/builtins.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtins.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: maabdull <maabdull@student.42abudhabi.ae>  +#+  +:+       +#+        */
+/*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 14:47:16 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/04 17:27:01 by maabdull         ###   ########.fr       */
+/*   Updated: 2024/05/13 15:30:52 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,7 +34,6 @@ bool	is_builtin(char *str)
 	}
 	return (false);
 }
-
 
 // TODO: Fix this temporary solution
 void	echo(char **cmd)
@@ -65,4 +64,3 @@ int	cd(char **cmd)
 	chdir(cmd[0]);
 	return (0);
 }
-

--- a/sources/cleanup/free.c
+++ b/sources/cleanup/free.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   free.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: maabdull <maabdull@student.42abudhabi.ae>  +#+  +:+       +#+        */
+/*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 17:38:52 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/04 17:39:35 by maabdull         ###   ########.fr       */
+/*   Updated: 2024/05/13 15:31:15 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,7 @@ void	free_tokens(t_minishell *minishell)
 void	free_cmd(t_cmd *cmd)
 {
 	t_cmd_exec	*cmd_exec;
-	int	i;
+	int			i;
 
 	i = 0;
 	if (cmd->type == CMD_EXEC)
@@ -43,5 +43,3 @@ void	free_cmd(t_cmd *cmd)
 		free(cmd_exec);
 	}
 }
-
-

--- a/sources/execution/exec.c
+++ b/sources/execution/exec.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: maabdull <maabdull@student.42abudhabi.ae>  +#+  +:+       +#+        */
+/*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 14:47:16 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/04 23:29:48 by maabdull         ###   ########.fr       */
+/*   Updated: 2024/05/13 15:31:32 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -108,4 +108,3 @@ void	exec_builtin(char **cmd)
 	if (ft_strncmp(cmd[0], "cd", 2) == 0)
 		g_status_code = cd(cmd + 1);
 }
-

--- a/sources/main.c
+++ b/sources/main.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/31 13:43:49 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/09 18:07:30 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/13 19:06:37 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,7 +29,7 @@ void	print_token(t_token token)
 {
 	char	*type;
 
-	switch (token.type) {
+	switch (token.type){
 		case PIPE:
 			type = "|";
 			break ;
@@ -45,13 +45,42 @@ void	print_token(t_token token)
 		case DBL_GREAT:
 			type = ">>";
 			break ;
-		default:
+		default :
 			type = "Word";
-			break ;
 	}
 	puts("{");
 	printf("\tContent: %s\n\tType: %s\n", token.content, type);
 	puts("}");
+}
+
+// We still need to come up with a proper cleanup.
+void	setup_environment(t_minishell *minishell, char **env)
+{
+	int			len;
+	t_env_node	*var;
+
+	while (*env)
+	{
+		var = malloc(sizeof(t_env_node));
+		if (!var)
+			write(2, "Malloc failed while setting up the env variables\n", 49);
+		len = ft_strchr(*env, '=') - *env;
+		var->env_name = ft_substr(*env, 0, len);
+		if (!var->env_name)
+			write(2, "Malloc failed while setting up the env variables\n", 49);
+		var->env_content = ft_substr(*env, len + 1, ft_strlen(*env) - len - 1);
+		if (!var->env_content)
+			write(2, "Malloc failed while setting up the env variables\n", 49);
+		var->env_print = true;
+		ft_lstadd_back(&minishell->env_variables, var);
+		env++;
+	}
+	// for (t_env_node *i = minishell->env_variables; i; i = i->next){
+	// 	puts("{");
+	// 	printf("\tType: %s\n\tContent: %s\n", "NAME", i->env_name);
+	// 	printf("\tType: %s\n\tContent: %s\n", "VALUE", i->env_content);
+	// 	puts("}\n");
+	// }
 }
 
 /*
@@ -60,16 +89,18 @@ void	print_token(t_token token)
  * frees the user read line.
  * NOTE: Readline causes still reachable memory leaks
  */
-int	main(int argc, char *argv[] __attribute__((unused)), char **env __attribute__((unused)))
+int	main(int argc, char *argv[] __attribute__((unused)), char **env)
 {
-	char	*line;
-	t_minishell minishell;
+	char		*line;
+	t_minishell	minishell;
 	// t_cmd	*cmd;
 
 	if (argc != 1)
 		return (puts("Minishell can not run external files."), 1);
 	g_status_code = 0;
 	// signal(SIGINT, handle_sigint);
+	ft_memset(&minishell, 0, sizeof(minishell));
+	setup_environment(&minishell, env);
 	minishell.prompt = init_prompt();
 	line = readline(minishell.prompt->current);
 	while (line)
@@ -81,7 +112,7 @@ int	main(int argc, char *argv[] __attribute__((unused)), char **env __attribute_
 		// free_cmd(cmd);
 		free(line);
 		for (int i = 0; i < minishell.token_count; i++){
-			print_token(minishell.tokens[i]);
+				print_token(minishell.tokens[i]);
 		}
 		free_tokens(&minishell);
 		update_prompt(minishell.prompt);

--- a/sources/parsing/create_cmd.c
+++ b/sources/parsing/create_cmd.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   create_cmd.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: maabdull <maabdull@student.42abudhabi.ae>  +#+  +:+       +#+        */
+/*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 17:34:36 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/04 17:34:46 by maabdull         ###   ########.fr       */
+/*   Updated: 2024/05/13 15:33:45 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,8 +15,8 @@
 t_cmd	*create_exec_cmd(t_minishell *minishell)
 {
 	t_cmd_exec	*exec_cmd;
-	t_token	*tokens;
-	int	i;
+	t_token		*tokens;
+	int			i;
 
 	i = 0;
 	exec_cmd = malloc(sizeof(t_cmd_exec));

--- a/sources/parsing/parser.c
+++ b/sources/parsing/parser.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 14:41:15 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/09 16:57:50 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/13 16:24:10 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,8 +14,8 @@
 
 int	count_quotations(char *line)
 {
-	int	count;
-	int	i;
+	int		count;
+	int		i;
 	char	quotes_found;
 
 	i = -1;
@@ -62,7 +62,7 @@ int	count_quotations(char *line)
  */
 char	*get_token(char	**input)
 {
-	int	i;
+	int		i;
 	char	*token;
 	char	*string;
 	char	quotes_found;
@@ -83,7 +83,7 @@ char	*get_token(char	**input)
 			space_found = true;
 			break ;
 		}
-		if (space_found && !quotes_found && !ft_isspace(string[i]))	
+		if (space_found && !quotes_found && !ft_isspace(string[i]))
 			space_found = false;
 		i++;
 	}
@@ -162,7 +162,7 @@ int	count_tokens(char *input)
 				space_found = true;
 			}
 		}
-		if (!quotes_found && input[i] != ' ')	
+		if (!quotes_found && input[i] != ' ')
 			space_found = false;
 		i++;
 	}
@@ -174,8 +174,8 @@ int	count_tokens(char *input)
 t_token	*tokenize(t_minishell *minishell, char *input)
 {
 	t_token	*tokens;
-	int	i;
-	int	token_count;
+	int		i;
+	int		token_count;
 
 	i = 0;
 	token_count = count_tokens(input);

--- a/sources/setup/prompt.c
+++ b/sources/setup/prompt.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   prompt.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: maabdull <maabdull@student.42abudhabi.ae>  +#+  +:+       +#+        */
+/*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 17:28:38 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/04 23:52:33 by maabdull         ###   ########.fr       */
+/*   Updated: 2024/05/13 15:34:44 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -69,4 +69,3 @@ void	update_prompt(t_prompt *prompt)
 	prompt->current = prompt_str;
 	return ;
 }
-

--- a/sources/utils/ft_lstadd_back.c
+++ b/sources/utils/ft_lstadd_back.c
@@ -1,0 +1,28 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_lstadd_back.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/13 18:57:19 by mdanish           #+#    #+#             */
+/*   Updated: 2024/05/13 18:57:37 by mdanish          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+void	ft_lstadd_back(t_env_node **list, t_env_node *new_node)
+{
+	t_env_node *last;
+
+	if (!*list)
+		*list = new_node;
+	else
+	{
+		last = *list;
+		while (last->next)
+			last = last->next;
+		last->next = new_node;
+	}
+}

--- a/sources/utils/ft_memset.c
+++ b/sources/utils/ft_memset.c
@@ -1,0 +1,25 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_memset.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/07/03 16:44:37 by mdanish           #+#    #+#             */
+/*   Updated: 2024/05/13 16:46:33 by mdanish          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+
+void	*ft_memset(void *string, int character, size_t length)
+{
+	unsigned char	*str;
+
+	if (!string)
+		return (NULL);
+	str = (unsigned char *)string;
+	while (length--)
+		*str++ = character;
+	return (string);
+}

--- a/sources/utils/module.mk
+++ b/sources/utils/module.mk
@@ -1,4 +1,4 @@
-UTILS_SRCS := $(addprefix $(UTILS_DIR)/, ft_join.c ft_printarr.c \
+UTILS_SRCS := $(addprefix $(UTILS_DIR)/, ft_join.c ft_lstadd_back.c ft_printarr.c ft_memset.c\
 	      ft_split.c ft_strchr.c ft_strcpy.c ft_strjoin.c ft_strlen.c \
 	      ft_strncmp.c ft_substr.c ft_free_2d_arr.c ft_strlcpy.c ft_strdup.c ft_char_strjoin.c ft_is_quotation.c ft_isspace.c)
 SRCS += $(UTILS_SRCS)


### PR DESCRIPTION
I parsed the environment variables to be stored in a list within the main `minishell` struct. For each node in that list, there is the name of the environment variable and the value stored within it. I have a block of code within the function to print the final result.

The purpose of this is for us to be able to easily locate the string whenever `$` is encountered, allowing us to replace it with the value of the variable.

There is an extra flag within the `env_var` nodes which is regarding the printing. Ignore that for now because I might remove it later. It may be used to help with the difference in behavior of the printing of `env` and `export`.