### PR TITLE
feat: added the unset builtin

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 17:24:25 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/15 15:11:12 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/15 16:41:55 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -123,6 +123,7 @@ void			run_cmd(t_cmd *cmd, char **env);
 int				ft_cd(char **cmd);
 void			ft_echo(char **cmd);
 void			ft_env(char **envp);
+void			ft_unset(t_minishell *minishell, char *variable);
 bool			is_builtin(char *str);
 
 // Cleanup

--- a/sources/builtins/builtins.c
+++ b/sources/builtins/builtins.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 14:47:16 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/15 15:17:59 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/15 16:56:05 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,6 +39,57 @@ void	ft_env(char **envp)
 {
 	while (*envp)
 		printf("%s\n", *envp++);
+	g_status_code = 0;
+}
+
+void	ft_unset_from_list(t_minishell *minishell, char *variable, int var_len)
+{
+	t_env_node	*delnode;
+	t_env_node	*store;
+
+	delnode = minishell->env_variables;
+	if (!ft_strncmp(variable, delnode->env_name, var_len))
+		minishell->env_variables = minishell->env_variables->next;
+	else
+	{
+		store = minishell->env_variables;
+		while (delnode)
+		{
+			delnode = delnode->next;
+			if (delnode && !ft_strncmp(variable, delnode->env_name, var_len))
+				break ;
+			store = store->next;
+		}
+		if (!delnode)
+			return ;
+		store->next = delnode->next;
+	}
+	free(delnode->env_name);
+	free(delnode->env_content);
+	free(delnode);
+}
+
+void	ft_unset(t_minishell *minishell, char *variable)
+{
+	int			var_len;
+	int			index;
+
+	index = -1;
+	var_len = ft_strlen(variable);
+	while (++index != minishell->envp_count)
+		if (!ft_strncmp(variable, minishell->envp[index], var_len))
+			break ;
+	if (index != minishell->envp_count)
+	{
+		free(minishell->envp[index]);
+		minishell->envp_count--;
+		while (index <= minishell->envp_count)
+		{
+			minishell->envp[index] = minishell->envp[index + 1];
+			index++;
+		}
+	}
+	ft_unset_from_list(minishell, variable, var_len);
 	g_status_code = 0;
 }
 


### PR DESCRIPTION
I added the `unset` builtin function. It works by
identifying the `variable` in question within the
two `lists` of the `environment variables` and
`deletes/frees` the `variable` and `content`. For the
change in the `matrix` list, it alters the pointers in a
manner similar to `lists`, where the deleted entry
is dropped from the indexing.

(PS: Forgot to push this earlier)