### PR TITLE
feat: added the export builtin

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 17:24:25 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/27 20:40:00 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/28 16:23:51 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -133,6 +133,7 @@ bool			is_argument_valid(const char *string);
 int				ft_cd(char **cmd);
 void			ft_echo(char **cmd);
 void			ft_env(char **envp);
+void			ft_pwd(char **args);
 void			ft_unset(t_minishell *minishell, char *variable);
 bool			is_builtin(char *str);
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 17:24:25 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/24 11:52:43 by maabdull         ###   ########.fr       */
+/*   Updated: 2024/05/27 20:40:00 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -77,7 +77,6 @@ struct s_env_node
 {
 	char		*env_name;
 	char		*env_content;
-	bool		env_print;
 	t_env_node	*next;
 };
 
@@ -122,6 +121,15 @@ int				exec_cmd(char **cmd, char **env);
 void			run_cmd(t_cmd *cmd, char **env);
 
 // Built-ins
+
+// Export
+void			ft_export(t_minishell *minishell, char **new_variable);
+bool			update_the_matrix(t_minishell *minishell, char *new_var);
+bool			check_for_existing_value(t_env_node *list, t_env_node *var, int len);
+void			create_new_variable(t_env_node *new_var, int *length, char *string);
+bool			is_argument_valid(const char *string);
+
+// Other		(Update the name later)
 int				ft_cd(char **cmd);
 void			ft_echo(char **cmd);
 void			ft_env(char **envp);

--- a/sources/builtins/builtins.c
+++ b/sources/builtins/builtins.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 14:47:16 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/15 16:56:05 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/28 16:22:41 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,6 +33,20 @@ bool	is_builtin(char *str)
 		i++;
 	}
 	return (false);
+}
+
+void	ft_pwd(char **args)
+{
+	char	*current_working_directory;
+	if (args && *args && **args)
+	{
+		write(2, "pwd does not accecpt options or arguments.\n", 43);
+		return ;
+	}
+	current_working_directory = getcwd(NULL, 0);
+	printf("%s\n", current_working_directory);
+	free(current_working_directory);
+	g_status_code = 0;
 }
 
 void	ft_env(char **envp)

--- a/sources/builtins/ft_export.c
+++ b/sources/builtins/ft_export.c
@@ -1,0 +1,103 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_export.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/15 19:45:08 by mdanish           #+#    #+#             */
+/*   Updated: 2024/05/27 20:20:59 by mdanish          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+void add_to_matrix(t_minishell *minishell, char *new_var)
+{
+	char	**env_store;
+	int		index;
+
+	if (!ft_strchr(new_var, '=') || update_the_matrix(minishell, new_var))
+		return ;
+	env_store = minishell->envp;
+	minishell->envp = malloc(sizeof(char *) * (minishell->envp_count + 2));
+	if (!minishell->envp)
+		write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+	ft_memset(minishell->envp, 0, sizeof(char **));
+	index = -1;
+	while (++index < minishell->envp_count)
+	{
+		minishell->envp[index] = ft_strdup(env_store[index]);
+		if (!minishell->envp[index])
+			write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+		free(env_store[index]);
+	}
+	free(env_store);
+	minishell->envp[minishell->envp_count] = ft_strdup(new_var);
+	if (!minishell->envp[index])
+		write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+	minishell->envp[++minishell->envp_count] = NULL;
+}
+
+static void	add_to_list(t_minishell *minishell, t_env_node *var, int len)
+{
+	t_env_node	*list;
+	t_env_node	*store;
+
+	list = minishell->env_variables;
+	while (list->next)
+	{
+		if (check_for_existing_value(list, var, len))
+			return ;
+		if (ft_strncmp(list->env_name, var->env_name, len) > 0)
+		{
+			var->next = list;
+			if (list == minishell->env_variables)
+				minishell->env_variables = var;
+			else
+				store->next = var;
+			return ;
+		}
+		store = list;
+		list = list->next;
+	}
+	list->next = var;
+}
+
+static void	ft_print_export(t_env_node *env)
+{
+	while (env)
+	{
+		if (env->env_content)
+			printf("declare -x %s=\"%s\"\n", env->env_name, env->env_content);
+		else
+			printf("declare -x %s\n", env->env_name);
+		env = env->next;
+	}
+}
+
+void	ft_export(t_minishell *minishell, char **new_variables)
+{
+	t_env_node	*var;
+	int			length;
+
+	g_status_code = 0;
+	if (!new_variables)
+	{
+		ft_print_export(minishell->env_variables);
+		return ;
+	}
+	while (*new_variables)
+	{
+		if (!is_argument_valid(*new_variables) && new_variables++)
+			continue ;
+		var = malloc(sizeof(t_env_node));
+		if (!var)
+			write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+		ft_memset(var, 0, sizeof(t_env_node));
+		create_new_variable(var, &length, *new_variables);
+		add_to_list(minishell, var, length);
+		add_to_matrix(minishell, *new_variables);
+		new_variables++;
+	}
+}

--- a/sources/builtins/ft_export_utils.c
+++ b/sources/builtins/ft_export_utils.c
@@ -1,0 +1,100 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_export_utils.c                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/27 20:21:11 by mdanish           #+#    #+#             */
+/*   Updated: 2024/05/27 20:22:07 by mdanish          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+bool	update_the_matrix(t_minishell *minishell, char *new_var)
+{
+	int	index;
+	int	length;
+
+	index = -1;
+	length = ft_strchr(new_var, '=') - new_var;
+	while (++index < minishell->envp_count)
+	{
+		char *store = minishell->envp[index];
+		if (ft_strncmp(store, new_var, length + 1))
+			continue ;
+		free( minishell->envp[index]);
+		minishell->envp[index] = malloc(ft_strlen(new_var) + 1);
+		if (!minishell->envp[index])
+			write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+		ft_strlcpy(minishell->envp[index], new_var, ft_strlen(new_var) + 1);
+		return (true);
+	}
+	return (false);
+}
+
+bool	check_for_existing_value(t_env_node *list, t_env_node *var, int len)
+{
+	if (!ft_strncmp(list->env_name, var->env_name, len))
+	{
+		if (var->env_content)
+		{
+			free(list->env_content);
+			list->env_content = var->env_content;
+			free(var->env_name);
+			free(var);
+		}
+		return (true);
+	}
+	return (false);
+}
+
+void	create_new_variable(t_env_node *new_var, int *length, char *string)
+{
+	if (!ft_strchr(string, '='))
+	{
+		new_var->env_name = ft_strdup(string);
+		if (!new_var->env_name)
+			write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+		*length = ft_strlen(new_var->env_name);
+	}
+	else
+	{
+		*length = ft_strchr(string, '=') - string;
+		new_var->env_name = ft_substr(string, 0, (*length));
+		if (!new_var->env_name)
+			write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+		new_var->env_content = ft_substr(string, *length + 1, \
+				ft_strlen(string) - (*length + 1));
+		if (!new_var->env_content)
+			write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+	}
+}
+
+bool	is_argument_valid(const char *string)
+{
+	int	index;
+
+	index = -1;
+	while (string[++index] && string[index] != '=')
+	{
+		if (string[index] == '_')
+			continue ;
+		else if (string[index] > 47 && string[index] < 58)
+			continue ;
+		else if ((string[index] > 64 && string[index] < 91) || \
+			(string[index] > 96 && string[index] < 123))
+			continue ;
+		else
+			break ;
+	}
+	if ((string[0] > 47 && string[0] < 58) || !string[0] || \
+		(string[index] && string[index] != '='))
+	{
+		write(2, "Invalid identifier detected in the arguments.\n", 46);
+		g_status_code = 1;
+		return (false);
+	}
+	return (true);
+}

--- a/sources/builtins/module.mk
+++ b/sources/builtins/module.mk
@@ -1,2 +1,2 @@
-BUILTIN_SRCS := $(addprefix $(BUILTIN_DIR)/, builtins.c)
+BUILTIN_SRCS := $(addprefix $(BUILTIN_DIR)/, builtins.c ft_export.c ft_export_utils.c)
 SRCS += $(BUILTIN_SRCS)

--- a/sources/main.c
+++ b/sources/main.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/31 13:43:49 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/24 12:14:09 by maabdull         ###   ########.fr       */
+/*   Updated: 2024/05/28 11:37:49 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,15 +14,15 @@
 
 int	g_status_code;
 
-// void	handle_sigint(int signum)
-// {
-// 	(void)signum;
-// 	puts("");
-// 	rl_on_new_line();
-// 	rl_replace_line("", 0);
-// 	rl_redisplay();
-// 	g_status_code = 130;
-// }
+void	handle_sigint(int signum)
+{
+	(void)signum;
+	puts("");
+	rl_on_new_line();
+	rl_replace_line("", 0);
+	rl_redisplay();
+	g_status_code = 130;
+}
 
 // TODO: Remove debug function
 void	print_token(t_token token)
@@ -74,7 +74,7 @@ int	main(int argc, char *argv[] __attribute__((unused)), char **env)
 	if (argc != 1)
 		return (write(2, "Minishell can not run external files.\n", 38) - 37);
 	g_status_code = 0;
-	// signal(SIGINT, handle_sigint);
+	signal(SIGINT, handle_sigint);
 	ft_memset(&minishell, 0, sizeof(minishell));
 	setup_environment(&minishell, env);
 	minishell.prompt = init_prompt();
@@ -87,10 +87,13 @@ int	main(int argc, char *argv[] __attribute__((unused)), char **env)
 		// run_cmd(cmd, env);
 		// free_cmd(cmd);
 		free(line);
-		for (int i = 0; i < minishell.token_count; i++){
-				print_token(minishell.tokens[i]);
+		if (minishell.token_count)
+		{
+			for (int i = 0; i < minishell.token_count; i++){
+					print_token(minishell.tokens[i]);
+			}
+			free_tokens(&minishell);
 		}
-		free_tokens(&minishell);
 		update_prompt(minishell.prompt);
 		line = readline(minishell.prompt->current);
 	}

--- a/sources/parsing/parser.c
+++ b/sources/parsing/parser.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 14:41:15 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/26 09:54:28 by maabdull         ###   ########.fr       */
+/*   Updated: 2024/05/28 11:34:45 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -246,6 +246,9 @@ t_token	*tokenize(t_minishell *minishell, char *input)
 void	parse(t_minishell *minishell, char *line)
 {
 	if (count_quotations(line))
+	{
 		write(2, RED "Open quotes detected, command rejected.\n" RESET, 50);
+		return ;
+	}
 	minishell->tokens = tokenize(minishell, line);
 }

--- a/sources/setup/environment.c
+++ b/sources/setup/environment.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/15 10:07:41 by mdanish           #+#    #+#             */
-/*   Updated: 2024/05/24 12:07:31 by maabdull         ###   ########.fr       */
+/*   Updated: 2024/05/27 20:43:31 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,14 +20,14 @@ void	create_matrix(t_minishell *minishell, char **env)
 		minishell->envp_count++;
 	minishell->envp = malloc((sizeof(char *) * (minishell->envp_count + 1)));
 	if (!minishell->envp)
-		write(2, "Malloc failed while setting up the env variables\n", 49);
+		write(2, "Malloc failed while setting up the env variables\n", 49);	// exit required
 	ft_memset(minishell->envp, 0, sizeof(char **));
 	i = -1;
 	while (++i < minishell->envp_count)
 	{
 		minishell->envp[i] = ft_strdup(env[i]);
 		if (!minishell->envp[i])
-			write(2, "Malloc failed while setting up the env variables\n", 49);
+			write(2, "Malloc failed while setting up the env variables\n", 49);	// exit required
 	}
 	minishell->envp[minishell->envp_count] = NULL;
 }
@@ -68,17 +68,15 @@ void	setup_environment(t_minishell *minishell, char **env)
 	{
 		var = malloc(sizeof(t_env_node));
 		if (!var)
-			write(2, "Malloc failed while setting up the env variables\n", 49);
-		ft_memset(var, 0, sizeof(t_env_node *));
+			write(2, "Malloc failed while setting up the env variables\n", 49);	// exit required
+		ft_memset(var, 0, sizeof(t_env_node));
 		len = ft_strchr(*env, '=') - *env;
 		var->env_name = ft_substr(*env, 0, len);
 		if (!var->env_name)
-			write(2, "Malloc failed while setting up the env variables\n", 49);
+			write(2, "Malloc failed while setting up the env variables\n", 49);	// exit required
 		var->env_content = ft_substr(*env, len + 1, ft_strlen(*env) - len - 1);
 		if (!var->env_content)
-			write(2, "Malloc failed while setting up the env variables\n", 49);
-		var->env_print = true;
-		var->next = NULL;
+			write(2, "Malloc failed while setting up the env variables\n", 49);	// exit required
 		ft_lstadd_back(&minishell->env_variables, var);
 		env++;
 	}


### PR DESCRIPTION
The `export` builtin is complete in all of its
functionality. When run without arguments, it will
print the list of environment variables in
alphabetical order. When run with arguments, it
will go through them to ensure validity and assign
the new variables to the `list` as well as the
`matrix` according to the behavior of the original
`export` builtin.

An empty value will not update the `matrix`. An
existing `key` without a `value` does nothing where
an existing `key` with a `value` is updated in the
`matrix` as well as `list`. A new `key` with no `value`
is added to the `matrix` and the `list`, and will display
the `key` correctly when prompted. A new `key` with
`value` is added to the `matrix` and the `list`.