### PR TITLE
feat: added the export, pwd and echo builtin

### DIFF
--- a/includes/libft.h
+++ b/includes/libft.h
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/13 15:29:04 by mdanish           #+#    #+#             */
-/*   Updated: 2024/05/28 23:51:18 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/29 12:17:27 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,15 @@
 # include <unistd.h>
 # include <stdbool.h>
 
+# define HEX_LOW "0123456789abcdef"
+# define HEX_UP "0123456789ABCDEF"
+# define DECIMAL "0123456789"
+
+void	ft_putchar_fd(char character, int fd);
+void	ft_putendl_fd(char *string, int fd);
+void	ft_putunbr_base_fd(long int number, int fd, char *base, int base_len);
+void	ft_putnbr_fd(long int number, int fd);
+void	ft_putstr_fd(char *string, int fd);
 char	*ft_char_strjoin(char const *s1, char const *s2, char const c);
 void	ft_free_2d_arr(char **arr);
 char	ft_is_quotation(char c);

--- a/includes/libft.h
+++ b/includes/libft.h
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/13 15:29:04 by mdanish           #+#    #+#             */
-/*   Updated: 2024/05/13 18:59:10 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/28 23:51:18 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,7 @@
 
 char	*ft_char_strjoin(char const *s1, char const *s2, char const c);
 void	ft_free_2d_arr(char **arr);
-char	ft_is_quotation(char c, char quote);
+char	ft_is_quotation(char c);
 bool	ft_isspace(char c);
 char	*ft_join(char **tab);
 void	*ft_memset(void *array, int character, size_t bytes);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 17:24:25 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/27 20:40:00 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/28 16:23:51 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -133,6 +133,7 @@ bool			is_argument_valid(const char *string);
 int				ft_cd(char **cmd);
 void			ft_echo(char **cmd);
 void			ft_env(char **envp);
+void			ft_pwd(char **args);
 void			ft_unset(t_minishell *minishell, char *variable);
 bool			is_builtin(char *str);
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 17:24:25 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/24 11:52:43 by maabdull         ###   ########.fr       */
+/*   Updated: 2024/05/27 20:40:00 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -77,7 +77,6 @@ struct s_env_node
 {
 	char		*env_name;
 	char		*env_content;
-	bool		env_print;
 	t_env_node	*next;
 };
 
@@ -122,6 +121,15 @@ int				exec_cmd(char **cmd, char **env);
 void			run_cmd(t_cmd *cmd, char **env);
 
 // Built-ins
+
+// Export
+void			ft_export(t_minishell *minishell, char **new_variable);
+bool			update_the_matrix(t_minishell *minishell, char *new_var);
+bool			check_for_existing_value(t_env_node *list, t_env_node *var, int len);
+void			create_new_variable(t_env_node *new_var, int *length, char *string);
+bool			is_argument_valid(const char *string);
+
+// Other		(Update the name later)
 int				ft_cd(char **cmd);
 void			ft_echo(char **cmd);
 void			ft_env(char **envp);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 17:24:25 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/28 16:23:51 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/29 15:48:49 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -75,8 +75,8 @@ struct s_prompt
 
 struct s_env_node
 {
-	char		*env_name;
-	char		*env_content;
+	char		*key;
+	char		*value;
 	t_env_node	*next;
 };
 
@@ -123,18 +123,17 @@ void			run_cmd(t_cmd *cmd, char **env);
 // Built-ins
 
 // Export
+void			add_to_matrix(t_minishell *minishell, char *new_var);
 void			ft_export(t_minishell *minishell, char **new_variable);
-bool			update_the_matrix(t_minishell *minishell, char *new_var);
-bool			check_for_existing_value(t_env_node *list, t_env_node *var, int len);
 void			create_new_variable(t_env_node *new_var, int *length, char *string);
 bool			is_argument_valid(const char *string);
 
 // Other		(Update the name later)
 int				ft_cd(char **cmd);
 void			ft_echo(char **cmd);
-void			ft_env(char **envp);
+void			ft_env(char **args, char **envp);
 void			ft_pwd(char **args);
-void			ft_unset(t_minishell *minishell, char *variable);
+void			ft_unset(t_minishell *minishell, char **variable);
 bool			is_builtin(char *str);
 
 // Cleanup

--- a/sources/builtins/builtins.c
+++ b/sources/builtins/builtins.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 14:47:16 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/28 23:46:37 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/29 12:40:31 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,11 +40,11 @@ void	ft_pwd(char **args)
 	char	*current_working_directory;
 	if (args && *args && **args)
 	{
-		write(2, "pwd does not accecpt options or arguments.\n", 43);
+		ft_putendl_fd("pwd does not accecpt options or arguments.", 2);
 		return ;
 	}
 	current_working_directory = getcwd(NULL, 0);
-	printf("%s\n", current_working_directory);
+	ft_putendl_fd(current_working_directory, 1);
 	free(current_working_directory);
 	g_status_code = 0;
 }
@@ -52,7 +52,10 @@ void	ft_pwd(char **args)
 void	ft_env(char **envp)
 {
 	while (*envp)
-		printf("%s\n", *envp++);
+	{
+		ft_putendl_fd(*envp, 1);
+		envp++;
+	}
 	g_status_code = 0;
 }
 
@@ -116,19 +119,19 @@ void	ft_echo(char **cmd)
 		index++;
 	while (cmd[index])
 	{
-		write(1, cmd[index], ft_strlen(cmd[index]));
+		ft_putstr_fd(cmd[index], 1);
 		if (cmd[++index])
-			write(1, " ", 1);
+			ft_putchar_fd(' ', 1);
 	}
 	if (ft_strncmp(cmd[1], "-n", 3))
-		write(1, "\n", 1);
+		ft_putchar_fd('\n', 1);
 	g_status_code = 0;
 }
 
 int	ft_cd(char **cmd)
 {
 	if (cmd[1])
-		return (fprintf(stderr, "cd: too many arguments\n"), 1);
+		return (ft_putendl_fd("cd: too many arguments", 2), 1);
 	chdir(cmd[0]);
 	return (0);
 }

--- a/sources/builtins/builtins.c
+++ b/sources/builtins/builtins.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 14:47:16 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/15 16:56:05 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/28 16:22:41 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,6 +33,20 @@ bool	is_builtin(char *str)
 		i++;
 	}
 	return (false);
+}
+
+void	ft_pwd(char **args)
+{
+	char	*current_working_directory;
+	if (args && *args && **args)
+	{
+		write(2, "pwd does not accecpt options or arguments.\n", 43);
+		return ;
+	}
+	current_working_directory = getcwd(NULL, 0);
+	printf("%s\n", current_working_directory);
+	free(current_working_directory);
+	g_status_code = 0;
 }
 
 void	ft_env(char **envp)

--- a/sources/builtins/builtins.c
+++ b/sources/builtins/builtins.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 14:47:16 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/28 19:05:38 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/28 23:46:37 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,7 @@ bool	is_builtin(char *str)
 	builtins[7] = NULL;
 	while (builtins[i])
 	{
-		if (ft_strncmp(str, builtins[i], ft_strlen(builtins[i])) == 0)
+		if (!ft_strncmp(str, builtins[i], ft_strlen(builtins[i]) + 1))
 			return (true);
 		i++;
 	}

--- a/sources/builtins/builtins.c
+++ b/sources/builtins/builtins.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 14:47:16 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/28 16:22:41 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/28 17:41:25 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -89,7 +89,7 @@ void	ft_unset(t_minishell *minishell, char *variable)
 	int			index;
 
 	index = -1;
-	var_len = ft_strlen(variable);
+	var_len = ft_strlen(variable) + 1;
 	while (++index != minishell->envp_count)
 		if (!ft_strncmp(variable, minishell->envp[index], var_len))
 			break ;
@@ -115,7 +115,7 @@ void		ft_echo(char **cmd)
 
 	i = 0;
 	display_newline = true;
-	if (ft_strncmp(cmd[i], "-n", 2) == 0)
+	if (ft_strncmp(cmd[i], "-n", 3) == 0)
 	{
 		i++;
 		display_newline = false;

--- a/sources/builtins/builtins.c
+++ b/sources/builtins/builtins.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 14:47:16 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/28 17:41:25 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/28 19:05:38 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -107,26 +107,22 @@ void	ft_unset(t_minishell *minishell, char *variable)
 	g_status_code = 0;
 }
 
-// TODO: Fix this temporary solution
-void		ft_echo(char **cmd)
+void	ft_echo(char **cmd)
 {
-	int		i;
-	bool	display_newline;
+	int	index;
 
-	i = 0;
-	display_newline = true;
-	if (ft_strncmp(cmd[i], "-n", 3) == 0)
+	index = 1;
+	if (!ft_strncmp(cmd[1], "-n", 3))
+		index++;
+	while (cmd[index])
 	{
-		i++;
-		display_newline = false;
+		write(1, cmd[index], ft_strlen(cmd[index]));
+		if (cmd[++index])
+			write(1, " ", 1);
 	}
-	while (cmd[i])
-	{
-		printf("%s ", cmd[i]);
-		i++;
-	}
-	if (display_newline)
-		puts("");
+	if (ft_strncmp(cmd[1], "-n", 3))
+		write(1, "\n", 1);
+	g_status_code = 0;
 }
 
 int	ft_cd(char **cmd)

--- a/sources/builtins/builtins.c
+++ b/sources/builtins/builtins.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 14:47:16 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/29 12:40:31 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/29 13:35:12 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,99 +33,6 @@ bool	is_builtin(char *str)
 		i++;
 	}
 	return (false);
-}
-
-void	ft_pwd(char **args)
-{
-	char	*current_working_directory;
-	if (args && *args && **args)
-	{
-		ft_putendl_fd("pwd does not accecpt options or arguments.", 2);
-		return ;
-	}
-	current_working_directory = getcwd(NULL, 0);
-	ft_putendl_fd(current_working_directory, 1);
-	free(current_working_directory);
-	g_status_code = 0;
-}
-
-void	ft_env(char **envp)
-{
-	while (*envp)
-	{
-		ft_putendl_fd(*envp, 1);
-		envp++;
-	}
-	g_status_code = 0;
-}
-
-void	ft_unset_from_list(t_minishell *minishell, char *variable, int var_len)
-{
-	t_env_node	*delnode;
-	t_env_node	*store;
-
-	delnode = minishell->env_variables;
-	if (!ft_strncmp(variable, delnode->env_name, var_len))
-		minishell->env_variables = minishell->env_variables->next;
-	else
-	{
-		store = minishell->env_variables;
-		while (delnode)
-		{
-			delnode = delnode->next;
-			if (delnode && !ft_strncmp(variable, delnode->env_name, var_len))
-				break ;
-			store = store->next;
-		}
-		if (!delnode)
-			return ;
-		store->next = delnode->next;
-	}
-	free(delnode->env_name);
-	free(delnode->env_content);
-	free(delnode);
-}
-
-void	ft_unset(t_minishell *minishell, char *variable)
-{
-	int			var_len;
-	int			index;
-
-	index = -1;
-	var_len = ft_strlen(variable) + 1;
-	while (++index != minishell->envp_count)
-		if (!ft_strncmp(variable, minishell->envp[index], var_len))
-			break ;
-	if (index != minishell->envp_count)
-	{
-		free(minishell->envp[index]);
-		minishell->envp_count--;
-		while (index <= minishell->envp_count)
-		{
-			minishell->envp[index] = minishell->envp[index + 1];
-			index++;
-		}
-	}
-	ft_unset_from_list(minishell, variable, var_len);
-	g_status_code = 0;
-}
-
-void	ft_echo(char **cmd)
-{
-	int	index;
-
-	index = 1;
-	if (!ft_strncmp(cmd[1], "-n", 3))
-		index++;
-	while (cmd[index])
-	{
-		ft_putstr_fd(cmd[index], 1);
-		if (cmd[++index])
-			ft_putchar_fd(' ', 1);
-	}
-	if (ft_strncmp(cmd[1], "-n", 3))
-		ft_putchar_fd('\n', 1);
-	g_status_code = 0;
 }
 
 int	ft_cd(char **cmd)

--- a/sources/builtins/ft_export.c
+++ b/sources/builtins/ft_export.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/15 19:45:08 by mdanish           #+#    #+#             */
-/*   Updated: 2024/05/28 17:44:00 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/29 13:06:30 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,20 +22,20 @@ void add_to_matrix(t_minishell *minishell, char *new_var)
 	env_store = minishell->envp;
 	minishell->envp = malloc(sizeof(char *) * (minishell->envp_count + 2));
 	if (!minishell->envp)
-		write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+		ft_putendl_fd("Malloc failed while exporting a variable.", 2);	// exit required
 	ft_memset(minishell->envp, 0, sizeof(char **));
 	index = -1;
 	while (++index < minishell->envp_count)
 	{
 		minishell->envp[index] = ft_strdup(env_store[index]);
 		if (!minishell->envp[index])
-			write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+			ft_putendl_fd("Malloc failed while exporting a variable.", 2);	// exit required
 		free(env_store[index]);
 	}
 	free(env_store);
 	minishell->envp[minishell->envp_count] = ft_strdup(new_var);
 	if (!minishell->envp[index])
-		write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+		ft_putendl_fd("Malloc failed while exporting a variable.", 2);	// exit required
 	minishell->envp[++minishell->envp_count] = NULL;
 }
 
@@ -68,10 +68,15 @@ static void	ft_print_export(t_env_node *env)
 {
 	while (env)
 	{
+		ft_putstr_fd("declare -x ", 1);
+		ft_putstr_fd(env->env_name, 1);
 		if (env->env_content)
-			printf("declare -x %s=\"%s\"\n", env->env_name, env->env_content);
-		else
-			printf("declare -x %s\n", env->env_name);
+		{
+			ft_putstr_fd("=\"", 1);
+			ft_putstr_fd(env->env_content, 1);
+			ft_putchar_fd('\"', 1);
+		}
+		ft_putchar_fd('\n', 1);
 		env = env->next;
 	}
 }
@@ -93,7 +98,7 @@ void	ft_export(t_minishell *minishell, char **new_variables)
 			continue ;
 		var = malloc(sizeof(t_env_node));
 		if (!var)
-			write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+			ft_putendl_fd("Malloc failed while exporting a variable.", 2);	// exit required
 		ft_memset(var, 0, sizeof(t_env_node));
 		create_new_variable(var, &length, *new_variables);
 		add_to_list(minishell, var, length);

--- a/sources/builtins/ft_export.c
+++ b/sources/builtins/ft_export.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/15 19:45:08 by mdanish           #+#    #+#             */
-/*   Updated: 2024/05/27 20:20:59 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/28 17:44:00 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,9 +47,9 @@ static void	add_to_list(t_minishell *minishell, t_env_node *var, int len)
 	list = minishell->env_variables;
 	while (list->next)
 	{
-		if (check_for_existing_value(list, var, len))
+		if (check_for_existing_value(list, var, len + 1))
 			return ;
-		if (ft_strncmp(list->env_name, var->env_name, len) > 0)
+		if (ft_strncmp(list->env_name, var->env_name, len + 1) > 0)
 		{
 			var->next = list;
 			if (list == minishell->env_variables)

--- a/sources/builtins/ft_export.c
+++ b/sources/builtins/ft_export.c
@@ -6,38 +6,61 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/15 19:45:08 by mdanish           #+#    #+#             */
-/*   Updated: 2024/05/29 13:06:30 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/29 16:37:44 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-void add_to_matrix(t_minishell *minishell, char *new_var)
-{
-	char	**env_store;
-	int		index;
+/**
+ * @brief Checks if the node key exists in the list
+ * 
+ * If it finds the key to already exist within the list, it ends up freeing the
+ * previous value, replacing it with the new value and then freeing the rest of
+ * the new node. This is only done if there is a new value.
+ * 
+ * In the case that the key exists but the value is NULL, nothing happens.
+ * 
+ * @param list is the linked list in which the key will be searched for.
+ * @param var is the new node of which the key will be searched for.
+ * @param len is the length of the key of the new node.
+ * 
+ * @return true if the key exists, false if the key is not found in the list
+ * 
+ */
 
-	if (!ft_strchr(new_var, '=') || update_the_matrix(minishell, new_var))
-		return ;
-	env_store = minishell->envp;
-	minishell->envp = malloc(sizeof(char *) * (minishell->envp_count + 2));
-	if (!minishell->envp)
-		ft_putendl_fd("Malloc failed while exporting a variable.", 2);	// exit required
-	ft_memset(minishell->envp, 0, sizeof(char **));
-	index = -1;
-	while (++index < minishell->envp_count)
+static bool	check_for_existing_value(t_env_node *list, t_env_node *var, int len)
+{
+	if (!ft_strncmp(list->key, var->key, len))
 	{
-		minishell->envp[index] = ft_strdup(env_store[index]);
-		if (!minishell->envp[index])
-			ft_putendl_fd("Malloc failed while exporting a variable.", 2);	// exit required
-		free(env_store[index]);
+		if (var->value)
+		{
+			free(list->value);
+			list->value = var->value;
+			free(var->key);
+			free(var);
+		}
+		return (true);
 	}
-	free(env_store);
-	minishell->envp[minishell->envp_count] = ft_strdup(new_var);
-	if (!minishell->envp[index])
-		ft_putendl_fd("Malloc failed while exporting a variable.", 2);	// exit required
-	minishell->envp[++minishell->envp_count] = NULL;
+	return (false);
 }
+
+/**
+ * @brief Adds the new node to the existing list of environment variables.
+ * 
+ * It first checks if the key in the new node exists already within the list
+ * using the check_for_existing_value() function. If it does not exist, it is
+ * added by identifying the correct place within the list according to the
+ * alphabetical order of the variables.
+ * 
+ * Once identified, it changes the pointers of the surrounging nodes to ensure
+ * that the new node is properly added to the list.
+ * 
+ * @param minishell is used to access the linked list of the variables.
+ * @param var is the new node that will be added to the linked list.
+ * @param len is the length of the key of the new node.
+ * 
+ */
 
 static void	add_to_list(t_minishell *minishell, t_env_node *var, int len)
 {
@@ -49,7 +72,7 @@ static void	add_to_list(t_minishell *minishell, t_env_node *var, int len)
 	{
 		if (check_for_existing_value(list, var, len + 1))
 			return ;
-		if (ft_strncmp(list->env_name, var->env_name, len + 1) > 0)
+		if (ft_strncmp(list->key, var->key, len + 1) > 0)
 		{
 			var->next = list;
 			if (list == minishell->env_variables)
@@ -64,22 +87,52 @@ static void	add_to_list(t_minishell *minishell, t_env_node *var, int len)
 	list->next = var;
 }
 
+/**
+ * @brief Prints the list of variables.
+ * 
+ * It goes through the linked list og env variables and prints them according
+ * to whethter there is a content or not using the put_fd functions.
+ * 
+ * @param env is the linked list of variables that will be printed to stdout.
+ * 
+ */
+
 static void	ft_print_export(t_env_node *env)
 {
 	while (env)
 	{
 		ft_putstr_fd("declare -x ", 1);
-		ft_putstr_fd(env->env_name, 1);
-		if (env->env_content)
+		ft_putstr_fd(env->key, 1);
+		if (env->value)
 		{
 			ft_putstr_fd("=\"", 1);
-			ft_putstr_fd(env->env_content, 1);
+			ft_putstr_fd(env->value, 1);
 			ft_putchar_fd('\"', 1);
 		}
 		ft_putchar_fd('\n', 1);
 		env = env->next;
 	}
 }
+
+/**
+ * @brief Adds new variables to the environment. / Prints the list of variables.
+ * 
+ * If new variables is NULL, it will print the list through ft_print_export().
+ * 
+ * For each varable, it identifies whether the variable abides by the rules of
+ * variable names. This is done by sending it to the is_argument_valid()
+ * function. If valid, it will create a new node and store the within it the
+ * key and value of the variable.
+ * 
+ * It then sends it to the add_to_list() and add_to_matrix() functions to add
+ * that node to the list and matrix respectively.
+ * 
+ * Upon completion, it sets g_status_code to 0.
+ * 
+ * @param minishell is used to access the matrix and list to add variables.
+ * @param new_variables will be exported individually. (NULL terminated)
+ * 
+ */
 
 void	ft_export(t_minishell *minishell, char **new_variables)
 {

--- a/sources/builtins/ft_export.c
+++ b/sources/builtins/ft_export.c
@@ -1,0 +1,103 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_export.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/15 19:45:08 by mdanish           #+#    #+#             */
+/*   Updated: 2024/05/27 20:20:59 by mdanish          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+void add_to_matrix(t_minishell *minishell, char *new_var)
+{
+	char	**env_store;
+	int		index;
+
+	if (!ft_strchr(new_var, '=') || update_the_matrix(minishell, new_var))
+		return ;
+	env_store = minishell->envp;
+	minishell->envp = malloc(sizeof(char *) * (minishell->envp_count + 2));
+	if (!minishell->envp)
+		write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+	ft_memset(minishell->envp, 0, sizeof(char **));
+	index = -1;
+	while (++index < minishell->envp_count)
+	{
+		minishell->envp[index] = ft_strdup(env_store[index]);
+		if (!minishell->envp[index])
+			write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+		free(env_store[index]);
+	}
+	free(env_store);
+	minishell->envp[minishell->envp_count] = ft_strdup(new_var);
+	if (!minishell->envp[index])
+		write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+	minishell->envp[++minishell->envp_count] = NULL;
+}
+
+static void	add_to_list(t_minishell *minishell, t_env_node *var, int len)
+{
+	t_env_node	*list;
+	t_env_node	*store;
+
+	list = minishell->env_variables;
+	while (list->next)
+	{
+		if (check_for_existing_value(list, var, len))
+			return ;
+		if (ft_strncmp(list->env_name, var->env_name, len) > 0)
+		{
+			var->next = list;
+			if (list == minishell->env_variables)
+				minishell->env_variables = var;
+			else
+				store->next = var;
+			return ;
+		}
+		store = list;
+		list = list->next;
+	}
+	list->next = var;
+}
+
+static void	ft_print_export(t_env_node *env)
+{
+	while (env)
+	{
+		if (env->env_content)
+			printf("declare -x %s=\"%s\"\n", env->env_name, env->env_content);
+		else
+			printf("declare -x %s\n", env->env_name);
+		env = env->next;
+	}
+}
+
+void	ft_export(t_minishell *minishell, char **new_variables)
+{
+	t_env_node	*var;
+	int			length;
+
+	g_status_code = 0;
+	if (!new_variables)
+	{
+		ft_print_export(minishell->env_variables);
+		return ;
+	}
+	while (*new_variables)
+	{
+		if (!is_argument_valid(*new_variables) && new_variables++)
+			continue ;
+		var = malloc(sizeof(t_env_node));
+		if (!var)
+			write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+		ft_memset(var, 0, sizeof(t_env_node));
+		create_new_variable(var, &length, *new_variables);
+		add_to_list(minishell, var, length);
+		add_to_matrix(minishell, *new_variables);
+		new_variables++;
+	}
+}

--- a/sources/builtins/ft_export_utils.c
+++ b/sources/builtins/ft_export_utils.c
@@ -1,0 +1,100 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_export_utils.c                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/27 20:21:11 by mdanish           #+#    #+#             */
+/*   Updated: 2024/05/27 20:22:07 by mdanish          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+bool	update_the_matrix(t_minishell *minishell, char *new_var)
+{
+	int	index;
+	int	length;
+
+	index = -1;
+	length = ft_strchr(new_var, '=') - new_var;
+	while (++index < minishell->envp_count)
+	{
+		char *store = minishell->envp[index];
+		if (ft_strncmp(store, new_var, length + 1))
+			continue ;
+		free( minishell->envp[index]);
+		minishell->envp[index] = malloc(ft_strlen(new_var) + 1);
+		if (!minishell->envp[index])
+			write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+		ft_strlcpy(minishell->envp[index], new_var, ft_strlen(new_var) + 1);
+		return (true);
+	}
+	return (false);
+}
+
+bool	check_for_existing_value(t_env_node *list, t_env_node *var, int len)
+{
+	if (!ft_strncmp(list->env_name, var->env_name, len))
+	{
+		if (var->env_content)
+		{
+			free(list->env_content);
+			list->env_content = var->env_content;
+			free(var->env_name);
+			free(var);
+		}
+		return (true);
+	}
+	return (false);
+}
+
+void	create_new_variable(t_env_node *new_var, int *length, char *string)
+{
+	if (!ft_strchr(string, '='))
+	{
+		new_var->env_name = ft_strdup(string);
+		if (!new_var->env_name)
+			write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+		*length = ft_strlen(new_var->env_name);
+	}
+	else
+	{
+		*length = ft_strchr(string, '=') - string;
+		new_var->env_name = ft_substr(string, 0, (*length));
+		if (!new_var->env_name)
+			write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+		new_var->env_content = ft_substr(string, *length + 1, \
+				ft_strlen(string) - (*length + 1));
+		if (!new_var->env_content)
+			write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+	}
+}
+
+bool	is_argument_valid(const char *string)
+{
+	int	index;
+
+	index = -1;
+	while (string[++index] && string[index] != '=')
+	{
+		if (string[index] == '_')
+			continue ;
+		else if (string[index] > 47 && string[index] < 58)
+			continue ;
+		else if ((string[index] > 64 && string[index] < 91) || \
+			(string[index] > 96 && string[index] < 123))
+			continue ;
+		else
+			break ;
+	}
+	if ((string[0] > 47 && string[0] < 58) || !string[0] || \
+		(string[index] && string[index] != '='))
+	{
+		write(2, "Invalid identifier detected in the arguments.\n", 46);
+		g_status_code = 1;
+		return (false);
+	}
+	return (true);
+}

--- a/sources/builtins/ft_export_utils.c
+++ b/sources/builtins/ft_export_utils.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/27 20:21:11 by mdanish           #+#    #+#             */
-/*   Updated: 2024/05/28 23:55:13 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/29 12:41:38 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,7 +27,7 @@ bool	update_the_matrix(t_minishell *minishell, char *new_var)
 		free( minishell->envp[index]);
 		minishell->envp[index] = malloc(ft_strlen(new_var) + 1);
 		if (!minishell->envp[index])
-			write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+			ft_putendl_fd("Malloc failed while exporting a variable.", 2);	// exit required
 		ft_strlcpy(minishell->envp[index], new_var, ft_strlen(new_var) + 1);
 		return (true);
 	}
@@ -56,7 +56,7 @@ void	create_new_variable(t_env_node *new_var, int *length, char *string)
 	{
 		new_var->env_name = ft_strdup(string);
 		if (!new_var->env_name)
-			write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+			ft_putendl_fd("Malloc failed while exporting a variable.", 2);	// exit required
 		*length = ft_strlen(new_var->env_name);
 	}
 	else
@@ -64,11 +64,11 @@ void	create_new_variable(t_env_node *new_var, int *length, char *string)
 		*length = ft_strchr(string, '=') - string;
 		new_var->env_name = ft_substr(string, 0, *length);
 		if (!new_var->env_name)
-			write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+			ft_putendl_fd("Malloc failed while exporting a variable.", 2);	// exit required
 		new_var->env_content = ft_substr(string, *length + 1, \
 				ft_strlen(string) - (*length + 1));
 		if (!new_var->env_content)
-			write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
+			ft_putendl_fd("Malloc failed while exporting a variable.", 2);	// exit required
 	}
 }
 
@@ -92,7 +92,7 @@ bool	is_argument_valid(const char *string)
 	if ((string[0] >= '0' && string[0] <= '9') || !string[0] || \
 		(string[index] && string[index] != '='))
 	{
-		write(2, "Invalid identifier detected in the arguments.\n", 46);
+		ft_putendl_fd("Invalid identifier detected in the arguments.", 2);
 		g_status_code = 1;
 		return (false);
 	}

--- a/sources/builtins/ft_export_utils.c
+++ b/sources/builtins/ft_export_utils.c
@@ -6,13 +6,27 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/27 20:21:11 by mdanish           #+#    #+#             */
-/*   Updated: 2024/05/29 12:41:38 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/29 16:31:53 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-bool	update_the_matrix(t_minishell *minishell, char *new_var)
+/**
+ * @brief Checks if the new_var key exists in the matrix
+ * 
+ * If it finds the key to already exist within the matrix, it frees the index
+ * and creates a duplicate of the new_var, which is then stored in that index.
+ * If it isn't found, it will do nothing
+ * 
+ * @param minishell contains the matrix in which the key will be searched for.
+ * @param new_var contain the key that will be searched for.
+ * 
+ * @return true if the key exists, false if the key is not found in the matrix
+ * 
+ */
+
+static bool	update_the_matrix(t_minishell *minishell, char *new_var)
 {
 	int	index;
 	int	length;
@@ -21,56 +35,107 @@ bool	update_the_matrix(t_minishell *minishell, char *new_var)
 	length = ft_strchr(new_var, '=') - new_var;
 	while (++index < minishell->envp_count)
 	{
-		char *store = minishell->envp[index];
-		if (ft_strncmp(store, new_var, length + 1))
+		if (ft_strncmp(minishell->envp[index], new_var, length + 1))
 			continue ;
-		free( minishell->envp[index]);
-		minishell->envp[index] = malloc(ft_strlen(new_var) + 1);
+		free(minishell->envp[index]);
+		minishell->envp[index] = ft_strdup(new_var);
 		if (!minishell->envp[index])
 			ft_putendl_fd("Malloc failed while exporting a variable.", 2);	// exit required
-		ft_strlcpy(minishell->envp[index], new_var, ft_strlen(new_var) + 1);
 		return (true);
 	}
 	return (false);
 }
 
-bool	check_for_existing_value(t_env_node *list, t_env_node *var, int len)
+/**
+ * @brief Adds the new node to the existing matrix of environment variables.
+ * 
+ * It first checks if the key exists already within the matrix using the
+ * update_the_matrix() function. If it does not exist, it is added to the end of
+ * the matrix be reallocating for a bigger matrix and then copying over from
+ * the previous matrix.
+ * 
+ * Each index is copied over storing the previous pointer within the
+ * corresponding index.
+ * 
+ * @param minishell is used to access the linked list of the variables.
+ * @param var is the new node that will be added to the linked list.
+ * @param len is the length of the key of the new node.
+ * 
+ */
+
+void	add_to_matrix(t_minishell *minishell, char *new_var)
 {
-	if (!ft_strncmp(list->env_name, var->env_name, len))
-	{
-		if (var->env_content)
-		{
-			free(list->env_content);
-			list->env_content = var->env_content;
-			free(var->env_name);
-			free(var);
-		}
-		return (true);
-	}
-	return (false);
+	char	**env_store;
+	int		index;
+
+	if (!ft_strchr(new_var, '=') || update_the_matrix(minishell, new_var))
+		return ;
+	env_store = malloc(sizeof(char *) * (minishell->envp_count + 2));
+	if (!env_store)
+		ft_putendl_fd("Malloc failed while exporting a variable.", 2);	// exit required
+	ft_memset(env_store, 0, sizeof(char *) * (minishell->envp_count + 2));
+	index = -1;
+	while (++index < minishell->envp_count)
+		env_store[index] = minishell->envp[index];
+	free(minishell->envp);
+	minishell->envp = env_store;
+	minishell->envp[minishell->envp_count] = ft_strdup(new_var);
+	if (!minishell->envp[index])
+		ft_putendl_fd("Malloc failed while exporting a variable.", 2);	// exit required
 }
+
+/**
+ * @brief Adds the information into the node.
+ * 
+ * It goes through the string to identify the key and uses ft_substr() to store
+ * a copy of the key within the new_var node.
+ * 
+ * It then uses ft_substr() to create a copy of the value and also stores it in
+ * the new_var node.
+ * 
+ * @param new_var is the node within which new data will be stored in.
+ * @param length is the address of the variable that will store key length.
+ * @param string contains the new key and value to be added.
+ * 
+ */
 
 void	create_new_variable(t_env_node *new_var, int *length, char *string)
 {
 	if (!ft_strchr(string, '='))
 	{
-		new_var->env_name = ft_strdup(string);
-		if (!new_var->env_name)
+		new_var->key = ft_strdup(string);
+		if (!new_var->key)
 			ft_putendl_fd("Malloc failed while exporting a variable.", 2);	// exit required
-		*length = ft_strlen(new_var->env_name);
+		*length = ft_strlen(new_var->key);
 	}
 	else
 	{
 		*length = ft_strchr(string, '=') - string;
-		new_var->env_name = ft_substr(string, 0, *length);
-		if (!new_var->env_name)
+		new_var->key = ft_substr(string, 0, *length);
+		if (!new_var->key)
 			ft_putendl_fd("Malloc failed while exporting a variable.", 2);	// exit required
-		new_var->env_content = ft_substr(string, *length + 1, \
+		new_var->value = ft_substr(string, *length + 1, \
 				ft_strlen(string) - (*length + 1));
-		if (!new_var->env_content)
+		if (!new_var->value)
 			ft_putendl_fd("Malloc failed while exporting a variable.", 2);	// exit required
 	}
 }
+
+/**
+ * @brief Validates the argument.
+ * 
+ * It will go through the key part of the string to identify if any character
+ * other than digits and alphabets, with the exception of the [ _ ], is used.
+ * It will also check if the first character of the key is a digit.
+ * 
+ * If any of these tests are positive, an error message is printed and the
+ * variable is not exported. Otherwise it does nothing.
+ * 
+ * @param string contain the key that needs to be tested.
+ * 
+ * @return true if valid, false if invalid.
+ * 
+ */
 
 bool	is_argument_valid(const char *string)
 {

--- a/sources/builtins/ft_export_utils.c
+++ b/sources/builtins/ft_export_utils.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/27 20:21:11 by mdanish           #+#    #+#             */
-/*   Updated: 2024/05/27 20:22:07 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/28 17:43:20 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -62,7 +62,7 @@ void	create_new_variable(t_env_node *new_var, int *length, char *string)
 	else
 	{
 		*length = ft_strchr(string, '=') - string;
-		new_var->env_name = ft_substr(string, 0, (*length));
+		new_var->env_name = ft_substr(string, 0, *length);
 		if (!new_var->env_name)
 			write(2, "Malloc failed while exporting a variable.\n", 42);	// exit required
 		new_var->env_content = ft_substr(string, *length + 1, \

--- a/sources/builtins/ft_export_utils.c
+++ b/sources/builtins/ft_export_utils.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/27 20:21:11 by mdanish           #+#    #+#             */
-/*   Updated: 2024/05/28 17:43:20 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/28 23:55:13 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -81,15 +81,15 @@ bool	is_argument_valid(const char *string)
 	{
 		if (string[index] == '_')
 			continue ;
-		else if (string[index] > 47 && string[index] < 58)
+		else if (string[index] >= '0' && string[index] <= '9')
 			continue ;
-		else if ((string[index] > 64 && string[index] < 91) || \
-			(string[index] > 96 && string[index] < 123))
+		else if ((string[index] >= 'A' && string[index] <= 'Z') || \
+			(string[index] >= 'a' && string[index] <= 'z'))
 			continue ;
 		else
 			break ;
 	}
-	if ((string[0] > 47 && string[0] < 58) || !string[0] || \
+	if ((string[0] >= '0' && string[0] <= '9') || !string[0] || \
 		(string[index] && string[index] != '='))
 	{
 		write(2, "Invalid identifier detected in the arguments.\n", 46);

--- a/sources/builtins/ft_unset.c
+++ b/sources/builtins/ft_unset.c
@@ -1,0 +1,104 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_unset.c                                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/29 13:34:56 by mdanish           #+#    #+#             */
+/*   Updated: 2024/05/29 16:36:14 by mdanish          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+/**
+ * @brief Deletes a variable from the linked list.
+ * 
+ * 
+ * It goes through the list to identify the node to be deleted. If it is the
+ * first node, the pointer in minishell is updated to point to the next of the
+ * node that will be deleted. If it is not the first one, upon identification,
+ * it changes the next-pointer of the previous node to point to the node that
+ * comes after the one to be deleted.
+ * 
+ * Once the pointers are updated, it frees the content of the node and then
+ * the node itself.
+ * 
+ * @param minishell is used to access the list to delete the variable.
+ * @param var is the variable that needs to be unset.
+ * @param var_len is the length of the variable that needs to be unset.
+ *
+ */
+
+static void	ft_unset_from_list(t_minishell *minishell, char *var, int var_len)
+{
+	t_env_node	*delnode;
+	t_env_node	*store;
+
+	delnode = minishell->env_variables;
+	if (!ft_strncmp(var, delnode->key, var_len))
+		minishell->env_variables = minishell->env_variables->next;
+	else
+	{
+		store = minishell->env_variables;
+		while (delnode)
+		{
+			delnode = delnode->next;
+			if (delnode && !ft_strncmp(var, delnode->key, var_len))
+				break ;
+			store = store->next;
+		}
+		if (!delnode)
+			return ;
+		store->next = delnode->next;
+	}
+	free(delnode->key);
+	free(delnode->value);
+	free(delnode);
+}
+
+/**
+ * @brief Deletes variables from the stores of the environment variables.
+ * 
+ * For each varable, it goes through the matrix and frees the matching index.
+ * It then replaces the current pointer with the pointer of the next variable
+ * to get rid of the need for reallocating the entire matrix.
+ * 
+ * After that, it uses ft_unset_from_list to delete the matching node from the
+ * linked list of variables.
+ * 
+ * Upon completion, it sets g_status_code to 0.
+ * 
+ * @param minishell is used to access the matrix and list to delete variables.
+ * @param variable are the variables that need to be unset. (NULL terminated)
+ *
+ */
+
+void	ft_unset(t_minishell *minishell, char **variable)
+{
+	int			var_len;
+	int			index;
+
+	while (*variable)
+	{
+		index = -1;
+		var_len = ft_strlen(*variable) + 1;
+		while (++index != minishell->envp_count)
+			if (!ft_strncmp(*variable, minishell->envp[index], var_len))
+				break ;
+		if (index != minishell->envp_count)
+		{
+			free(minishell->envp[index]);
+			minishell->envp_count--;
+			while (index <= minishell->envp_count)
+			{
+				minishell->envp[index] = minishell->envp[index + 1];
+				index++;
+			}
+		}
+		ft_unset_from_list(minishell, *variable, var_len);
+		variable++;
+	}
+	g_status_code = 0;
+}

--- a/sources/builtins/module.mk
+++ b/sources/builtins/module.mk
@@ -1,2 +1,2 @@
-BUILTIN_SRCS := $(addprefix $(BUILTIN_DIR)/, builtins.c)
+BUILTIN_SRCS := $(addprefix $(BUILTIN_DIR)/, builtins.c ft_export.c ft_export_utils.c)
 SRCS += $(BUILTIN_SRCS)

--- a/sources/builtins/module.mk
+++ b/sources/builtins/module.mk
@@ -1,2 +1,3 @@
-BUILTIN_SRCS := $(addprefix $(BUILTIN_DIR)/, builtins.c ft_export.c ft_export_utils.c)
+BUILTIN_SRCS := $(addprefix $(BUILTIN_DIR)/, builtins.c ft_export.c \
+				ft_export_utils.c ft_unset.c simple_builtins.c)
 SRCS += $(BUILTIN_SRCS)

--- a/sources/builtins/simple_builtins.c
+++ b/sources/builtins/simple_builtins.c
@@ -1,0 +1,110 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   simple_builtins.c                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/29 13:21:03 by mdanish           #+#    #+#             */
+/*   Updated: 2024/05/29 16:37:00 by mdanish          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+/**
+ * @brief Prints to standard output a line of text.
+ * 
+ * It printf the arguments till cmd reaches null. While printing, it ensures
+ * there is an argument after the current one before it prints a space to act
+ * as a delimiter between the arguments.
+ * 
+ * It then confirms that the first argument is not the [ -n ] flag and prints
+ * the new line after it.
+ * 
+ * After completion, it sets the g_status_code to 0.
+ * 
+ * @param cmd points to the strings ft_echo needs to print. (NULL terminated)
+ *
+ */
+
+void	ft_echo(char **cmd)
+{
+	int	index;
+
+	index = 1;
+	if (!ft_strncmp(cmd[1], "-n", 3))
+		index++;
+	while (cmd[index])
+	{
+		ft_putstr_fd(cmd[index], 1);
+		if (cmd[++index])
+			ft_putchar_fd(' ', 1);
+	}
+	if (ft_strncmp(cmd[1], "-n", 3))
+		ft_putchar_fd('\n', 1);
+	g_status_code = 0;
+}
+
+/**
+ * @brief Prints to standard output the environment variables.
+ * 
+ * It goes through the matrix of the environment variables and sends them to
+ * ft_putendl_fd() to print to stdout.
+ * 
+ * Options or arguments will result in an error message and the g_status_code
+ * being set to 1.
+ * 
+ * Upon completion, it sets the g_status_code to 0.
+ * 
+ * @param args a char ** pointing to the arguments sent by the command line.
+ * @param envp a char ** pointing to the matrix ft_env needs to print.
+ *
+ */
+
+void	ft_env(char **args, char **envp)
+{
+	if (args && *args && **args)
+	{
+		ft_putendl_fd("env does not accecpt options or arguments.", 2);
+		g_status_code = 1;
+		return ;
+	}
+	while (*envp)
+	{
+		ft_putendl_fd(*envp, 1);
+		envp++;
+	}
+	g_status_code = 0;
+}
+
+/**
+ * @brief Prints to standard output the current working directory.
+ * 
+ * Gets the current working directory through a call to the getcwd() function
+ * and prints it to the stdout using ft_putendl_fd().
+ * 
+ * Options or arguments will result in an error message and
+ * the g_status_code being set to 1.
+ * 
+ * Upon completion, it sets the g_status_code to 0.
+ * 
+ * @param envp a char ** pointing to the matrix ft_env needs to print.
+ *
+ */
+
+void	ft_pwd(char **args)
+{
+	char	*current_working_directory;
+
+	if (args && *args && **args)
+	{
+		ft_putendl_fd("pwd does not accecpt options or arguments.", 2);
+		g_status_code = 1;
+		return ;
+	}
+	current_working_directory = getcwd(NULL, 0);
+	ft_putendl_fd(current_working_directory, 1);
+	free(current_working_directory);
+	g_status_code = 0;
+}

--- a/sources/execution/exec.c
+++ b/sources/execution/exec.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 14:47:16 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/15 14:50:18 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/29 12:34:08 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -75,23 +75,34 @@ int	exec_cmd(char **cmd, char **env)
 	{
 		absolute_cmd = find_cmd(cmd[0]);
 		if (!absolute_cmd)
-			return (fprintf(stderr, "%s: command not found\n", cmd_original), 127);
+		{
+			ft_putstr_fd(cmd_original, 2);
+			ft_putendl_fd(": command not found", 2);
+			return (127);
+		}
 		cmd[0] = absolute_cmd;
 	}
 	else
 	{
 		if (access(cmd[0], F_OK) == -1)
-			return (fprintf(stderr, "%s: no such file or directory\n",
-					cmd_original), 127);
+		{
+			ft_putstr_fd(cmd_original, 2);
+			ft_putendl_fd(": no such file or directory", 2);
+			return (127);
+		}
 		else if (access(cmd[0], X_OK) == -1)
-			return (fprintf(stderr, "%s: permission denied\n", cmd_original),
-				126);
+		{
+			ft_putstr_fd(cmd_original, 2);
+			ft_putendl_fd(": Permission denied", 2);
+			return (126);
+		}
 	}
 	pid = fork();
 	if (pid == 0)
 	{
 		execve(cmd[0], cmd, env);
-		fprintf(stderr, "%s: command not found\n", cmd_original);
+		ft_putstr_fd(cmd_original, 2);
+		ft_putendl_fd(": command not found", 2);
 		free(cmd_original);
 		exit(127);
 	}

--- a/sources/main.c
+++ b/sources/main.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/31 13:43:49 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/24 12:14:09 by maabdull         ###   ########.fr       */
+/*   Updated: 2024/05/28 11:37:49 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,15 +14,15 @@
 
 int	g_status_code;
 
-// void	handle_sigint(int signum)
-// {
-// 	(void)signum;
-// 	puts("");
-// 	rl_on_new_line();
-// 	rl_replace_line("", 0);
-// 	rl_redisplay();
-// 	g_status_code = 130;
-// }
+void	handle_sigint(int signum)
+{
+	(void)signum;
+	puts("");
+	rl_on_new_line();
+	rl_replace_line("", 0);
+	rl_redisplay();
+	g_status_code = 130;
+}
 
 // TODO: Remove debug function
 void	print_token(t_token token)
@@ -74,7 +74,7 @@ int	main(int argc, char *argv[] __attribute__((unused)), char **env)
 	if (argc != 1)
 		return (write(2, "Minishell can not run external files.\n", 38) - 37);
 	g_status_code = 0;
-	// signal(SIGINT, handle_sigint);
+	signal(SIGINT, handle_sigint);
 	ft_memset(&minishell, 0, sizeof(minishell));
 	setup_environment(&minishell, env);
 	minishell.prompt = init_prompt();
@@ -87,10 +87,13 @@ int	main(int argc, char *argv[] __attribute__((unused)), char **env)
 		// run_cmd(cmd, env);
 		// free_cmd(cmd);
 		free(line);
-		for (int i = 0; i < minishell.token_count; i++){
-				print_token(minishell.tokens[i]);
+		if (minishell.token_count)
+		{
+			for (int i = 0; i < minishell.token_count; i++){
+					print_token(minishell.tokens[i]);
+			}
+			free_tokens(&minishell);
 		}
-		free_tokens(&minishell);
 		update_prompt(minishell.prompt);
 		line = readline(minishell.prompt->current);
 	}

--- a/sources/main.c
+++ b/sources/main.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/31 13:43:49 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/28 11:37:49 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/29 12:38:07 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,7 @@ int	g_status_code;
 void	handle_sigint(int signum)
 {
 	(void)signum;
-	puts("");
+	ft_putchar_fd('\n', 1);
 	rl_on_new_line();
 	rl_replace_line("", 0);
 	rl_redisplay();
@@ -54,9 +54,11 @@ void	print_token(t_token token)
 		default :
 			type = "Word";
 	}
-	puts("{");
-	printf("\tContent: %s\n\tType: %s\n", token.content, type);
-	puts("}");
+	ft_putstr_fd("{\n\tContent: ", 1);
+	ft_putstr_fd(token.content, 1);
+	ft_putstr_fd("\n\tType: ", 1);
+	ft_putstr_fd(type, 1);
+	ft_putstr_fd("\n}\n", 1);
 }
 
 /*
@@ -72,7 +74,7 @@ int	main(int argc, char *argv[] __attribute__((unused)), char **env)
 	// t_cmd	*cmd;
 
 	if (argc != 1)
-		return (write(2, "Minishell can not run external files.\n", 38) - 37);
+		return (ft_putendl_fd("Minishell can not run external files.", 2), 1);
 	g_status_code = 0;
 	signal(SIGINT, handle_sigint);
 	ft_memset(&minishell, 0, sizeof(minishell));
@@ -100,6 +102,6 @@ int	main(int argc, char *argv[] __attribute__((unused)), char **env)
 	free(minishell.prompt->previous);
 	free(minishell.prompt->current);
 	free(minishell.prompt);
-	puts("exit");
+	ft_putendl_fd("exit", 1);
 	return (g_status_code);
 }

--- a/sources/parsing/parser.c
+++ b/sources/parsing/parser.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 14:41:15 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/28 11:34:45 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/28 23:53:01 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -105,18 +105,15 @@ char	*get_token(char **input)
 	int		i;
 	char	*token;
 	char	*string;
-	char	quotes_found;
 
 	i = -1;
-	quotes_found = '\0';
 	token = NULL;
 	string = *input;
 	while (ft_isspace(*string))
 		string++;
 	while (string[++i])
 	{
-		quotes_found = ft_is_quotation(string[i], quotes_found);
-		if (quotes_found)
+		if (ft_is_quotation(string[i]))
 			continue;
 		if (is_delimiter(string[i]))
 		{
@@ -188,17 +185,14 @@ int	count_tokens(char *input)
 {
 	int		i;
 	int		token_count;
-	char	quotes_found;
 
 	i = -1;
 	token_count = 0;
-	quotes_found = '\0';
 	while (ft_isspace(*input))
 		input++;
 	while (input[++i])
 	{
-		quotes_found = ft_is_quotation(input[i], quotes_found);
-		if (quotes_found)
+		if (ft_is_quotation(input[i]))
 			continue ;
 		if (ft_isspace(input[i]) && input[i + 1])
 		{

--- a/sources/parsing/parser.c
+++ b/sources/parsing/parser.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 14:41:15 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/26 09:54:28 by maabdull         ###   ########.fr       */
+/*   Updated: 2024/05/28 11:34:45 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -246,6 +246,9 @@ t_token	*tokenize(t_minishell *minishell, char *input)
 void	parse(t_minishell *minishell, char *line)
 {
 	if (count_quotations(line))
+	{
 		write(2, RED "Open quotes detected, command rejected.\n" RESET, 50);
+		return ;
+	}
 	minishell->tokens = tokenize(minishell, line);
 }

--- a/sources/parsing/parser.c
+++ b/sources/parsing/parser.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 14:41:15 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/28 23:53:01 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/29 12:46:09 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -226,7 +226,9 @@ t_token	*tokenize(t_minishell *minishell, char *input)
 	token_count = count_tokens(input);
 	minishell->token_count = token_count;
 	tokens = malloc((token_count + 1) * sizeof(t_token));
-	printf("There are %d tokens in your input\n", token_count);
+	ft_putstr_fd("There are ", 1);
+	ft_putnbr_fd(token_count, 1);
+	ft_putendl_fd(" tokens in your input", 1);
 	while (i < token_count)
 	{
 		tokens[i].content = get_token(&input);
@@ -241,7 +243,7 @@ void	parse(t_minishell *minishell, char *line)
 {
 	if (count_quotations(line))
 	{
-		write(2, RED "Open quotes detected, command rejected.\n" RESET, 50);
+		ft_putstr_fd(RED "Open quotes detected, command rejected.\n" RESET, 2);
 		return ;
 	}
 	minishell->tokens = tokenize(minishell, line);

--- a/sources/setup/environment.c
+++ b/sources/setup/environment.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/15 10:07:41 by mdanish           #+#    #+#             */
-/*   Updated: 2024/05/24 12:07:31 by maabdull         ###   ########.fr       */
+/*   Updated: 2024/05/27 20:43:31 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,14 +20,14 @@ void	create_matrix(t_minishell *minishell, char **env)
 		minishell->envp_count++;
 	minishell->envp = malloc((sizeof(char *) * (minishell->envp_count + 1)));
 	if (!minishell->envp)
-		write(2, "Malloc failed while setting up the env variables\n", 49);
+		write(2, "Malloc failed while setting up the env variables\n", 49);	// exit required
 	ft_memset(minishell->envp, 0, sizeof(char **));
 	i = -1;
 	while (++i < minishell->envp_count)
 	{
 		minishell->envp[i] = ft_strdup(env[i]);
 		if (!minishell->envp[i])
-			write(2, "Malloc failed while setting up the env variables\n", 49);
+			write(2, "Malloc failed while setting up the env variables\n", 49);	// exit required
 	}
 	minishell->envp[minishell->envp_count] = NULL;
 }
@@ -68,17 +68,15 @@ void	setup_environment(t_minishell *minishell, char **env)
 	{
 		var = malloc(sizeof(t_env_node));
 		if (!var)
-			write(2, "Malloc failed while setting up the env variables\n", 49);
-		ft_memset(var, 0, sizeof(t_env_node *));
+			write(2, "Malloc failed while setting up the env variables\n", 49);	// exit required
+		ft_memset(var, 0, sizeof(t_env_node));
 		len = ft_strchr(*env, '=') - *env;
 		var->env_name = ft_substr(*env, 0, len);
 		if (!var->env_name)
-			write(2, "Malloc failed while setting up the env variables\n", 49);
+			write(2, "Malloc failed while setting up the env variables\n", 49);	// exit required
 		var->env_content = ft_substr(*env, len + 1, ft_strlen(*env) - len - 1);
 		if (!var->env_content)
-			write(2, "Malloc failed while setting up the env variables\n", 49);
-		var->env_print = true;
-		var->next = NULL;
+			write(2, "Malloc failed while setting up the env variables\n", 49);	// exit required
 		ft_lstadd_back(&minishell->env_variables, var);
 		env++;
 	}

--- a/sources/setup/environment.c
+++ b/sources/setup/environment.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/15 10:07:41 by mdanish           #+#    #+#             */
-/*   Updated: 2024/05/27 20:43:31 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/29 12:46:47 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,14 +30,14 @@ static void	create_matrix(t_minishell *minishell, char **env)
 		minishell->envp_count++;
 	minishell->envp = malloc((sizeof(char *) * (minishell->envp_count + 1)));
 	if (!minishell->envp)
-		write(2, "Malloc failed while setting up the env variables\n", 49);	// exit required
+		ft_putendl_fd("Malloc failed while setting up the env variables", 2);	// exit required
 	ft_memset(minishell->envp, 0, sizeof(char **));
 	i = -1;
 	while (++i < minishell->envp_count)
 	{
 		minishell->envp[i] = ft_strdup(env[i]);
 		if (!minishell->envp[i])
-			write(2, "Malloc failed while setting up the env variables\n", 49);	// exit required
+			ft_putendl_fd("Malloc failed while setting up the env variables", 2);	// exit required
 	}
 	minishell->envp[minishell->envp_count] = NULL;
 }

--- a/sources/setup/environment.c
+++ b/sources/setup/environment.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/15 10:07:41 by mdanish           #+#    #+#             */
-/*   Updated: 2024/05/29 12:46:47 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/05/29 15:48:49 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,7 +49,8 @@ static void	create_matrix(t_minishell *minishell, char **env)
  * 
  * @param env is the list of environment variables that need to be sorted.
  * @param env_count is the total number of the environment variables.
- *
+ * 
+ * @return the final sorted matrix of the env.
  */
 
 static char	**sort_environment_variables(char **env, int env_count)
@@ -105,11 +106,11 @@ void	setup_environment(t_minishell *minishell, char **env)
 			break ;
 		ft_memset(var, 0, sizeof(t_env_node));
 		len = ft_strchr(*env, '=') - *env;
-		var->env_name = ft_substr(*env, 0, len);
-		if (!var->env_name)
+		var->key = ft_substr(*env, 0, len);
+		if (!var->key)
 			break ;
-		var->env_content = ft_substr(*env, len + 1, ft_strlen(*env) - len - 1);
-		if (!var->env_content)
+		var->value = ft_substr(*env, len + 1, ft_strlen(*env) - len - 1);
+		if (!var->value)
 			break ;
 		ft_lstadd_back(&minishell->env_variables, var);
 		env++;

--- a/sources/setup/environment.c
+++ b/sources/setup/environment.c
@@ -12,7 +12,17 @@
 
 #include "minishell.h"
 
-void	create_matrix(t_minishell *minishell, char **env)
+/**
+ * @brief Creates the matrix duplicate of the environment variables.
+ * 
+ * It is done by mallocing for a char ** and the running ft_strdup() on each
+ * index of env and it is then stored in the newly allocated matrix.
+ * 
+ * @param minishell is used to store the matrix duplication.
+ * @param env is used to create the matrix duplication from.
+ */
+
+static void	create_matrix(t_minishell *minishell, char **env)
 {
 	int	i;
 
@@ -32,7 +42,17 @@ void	create_matrix(t_minishell *minishell, char **env)
 	minishell->envp[minishell->envp_count] = NULL;
 }
 
-char	**sort_environment_variables(char **env, int env_count)
+/**
+ * @brief Sorts the list of the environment variables into alphabetical order.
+ * 
+ * It uses an implementation of bubble sort to achieve the result.
+ * 
+ * @param env is the list of environment variables that need to be sorted.
+ * @param env_count is the total number of the environment variables.
+ *
+ */
+
+static char	**sort_environment_variables(char **env, int env_count)
 {
 	char	*store;
 	int		i;
@@ -57,6 +77,20 @@ char	**sort_environment_variables(char **env, int env_count)
 
 // We still need to come up with a proper cleanup.
 // The cleanup will require a listclear function as well.
+
+/**
+ * @brief Creates a duplicate of the environment variable in the form of a
+ * char ** matrix as well as a linked list.
+ * 
+ * It uses the create_matrix() function to create the char ** matrix and then
+ * creates a linked list of the * variables after the variables are sorted by
+ * sort_environment_variables().
+ * 
+ * @param minishell is used to store the final duplicates.
+ * @param env is used to create the duplicates from.
+ *
+ */
+
 void	setup_environment(t_minishell *minishell, char **env)
 {
 	int			len;
@@ -68,22 +102,19 @@ void	setup_environment(t_minishell *minishell, char **env)
 	{
 		var = malloc(sizeof(t_env_node));
 		if (!var)
-			write(2, "Malloc failed while setting up the env variables\n", 49);	// exit required
+			break ;
 		ft_memset(var, 0, sizeof(t_env_node));
 		len = ft_strchr(*env, '=') - *env;
 		var->env_name = ft_substr(*env, 0, len);
 		if (!var->env_name)
-			write(2, "Malloc failed while setting up the env variables\n", 49);	// exit required
+			break ;
 		var->env_content = ft_substr(*env, len + 1, ft_strlen(*env) - len - 1);
 		if (!var->env_content)
-			write(2, "Malloc failed while setting up the env variables\n", 49);	// exit required
+			break ;
 		ft_lstadd_back(&minishell->env_variables, var);
 		env++;
 	}
-	// for (t_env_node *i = minishell->env_variables; i; i = i->next){
-	// 	puts("{");
-	// 	printf("\tType: %s\n\tContent: %s\n", "NAME", i->env_name);
-	// 	printf("\tType: %s\n\tContent: %s\n", "VALUE", i->env_content);
-	// 	puts("}\n");
-	// }
+	if (!*env)
+		return ;
+	ft_putendl_fd("Malloc failed while setting up the env variables", 2);	// exit required
 }

--- a/sources/setup/prompt.c
+++ b/sources/setup/prompt.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 17:28:38 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/23 23:41:10 by maabdull         ###   ########.fr       */
+/*   Updated: 2024/05/28 23:48:06 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,7 +47,7 @@ void	update_prompt(t_prompt *prompt)
 	if (home_dir && current_dir)
 	{
 		i = ft_strlen(home_dir);
-		if (ft_strncmp(current_dir, home_dir, i) == 0)
+		if (ft_strncmp(current_dir, home_dir, i + 1) == 0)
 		{
 			prompt_str = ft_strjoin(prompt_str, "~");
 			temp = prompt_str;

--- a/sources/utils/ft_is_quotation.c
+++ b/sources/utils/ft_is_quotation.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ft_is_quotation.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: maabdull <maabdull@student.42abudhabi.ae>  +#+  +:+       +#+        */
+/*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 13:50:06 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/04 14:20:55 by maabdull         ###   ########.fr       */
+/*   Updated: 2024/05/28 23:50:49 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,8 +34,10 @@
  * Should return:
  * '"'
  */
-char	ft_is_quotation(char c, char quote)
+char	ft_is_quotation(char c)
 {
+	static char quote = '\0';
+
 	if (c == '"')
 	{
 		if (!quote)

--- a/sources/utils/ft_putchar_fd.c
+++ b/sources/utils/ft_putchar_fd.c
@@ -1,30 +1,19 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   ft_printarr.c                                      :+:      :+:    :+:   */
+/*   ft_putchar_fd.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2024/04/03 20:06:36 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/29 12:47:39 by mdanish          ###   ########.fr       */
+/*   Created: 2023/07/16 14:38:09 by mdanish           #+#    #+#             */
+/*   Updated: 2024/05/29 12:14:29 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-/* Prints the specified array of strings, separated by newlines */
-int	ft_printarr(char **tab)
+void	ft_putchar_fd(char character, int fd)
 {
-	int	i;
-
-	i = 0;
-	while (tab[i])
-	{
-		ft_putstr_fd(tab[i], 1);
-		if (tab[i + 1])
-			ft_putstr_fd(", ", 1);
-		i++;
-	}
-	ft_putchar_fd('\n', 1);
-	return (0);
+	if (fd >= 0)
+		write(fd, &character, 1);
 }

--- a/sources/utils/ft_putendl_fd.c
+++ b/sources/utils/ft_putendl_fd.c
@@ -1,30 +1,22 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   ft_printarr.c                                      :+:      :+:    :+:   */
+/*   ft_putendl_fd.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2024/04/03 20:06:36 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/29 12:47:39 by mdanish          ###   ########.fr       */
+/*   Created: 2023/07/16 14:55:49 by mdanish           #+#    #+#             */
+/*   Updated: 2024/05/29 12:15:24 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-/* Prints the specified array of strings, separated by newlines */
-int	ft_printarr(char **tab)
+void	ft_putendl_fd(char *string, int fd)
 {
-	int	i;
-
-	i = 0;
-	while (tab[i])
+	if (fd >= 0)
 	{
-		ft_putstr_fd(tab[i], 1);
-		if (tab[i + 1])
-			ft_putstr_fd(", ", 1);
-		i++;
+		ft_putstr_fd(string, fd);
+		ft_putchar_fd('\n', fd);
 	}
-	ft_putchar_fd('\n', 1);
-	return (0);
 }

--- a/sources/utils/ft_putnbr_base_fd.c
+++ b/sources/utils/ft_putnbr_base_fd.c
@@ -1,30 +1,23 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   ft_printarr.c                                      :+:      :+:    :+:   */
+/*   ft_putnbr_base_fd.c                                :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2024/04/03 20:06:36 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/29 12:47:39 by mdanish          ###   ########.fr       */
+/*   Created: 2023/10/22 10:38:05 by mdanish           #+#    #+#             */
+/*   Updated: 2024/05/29 12:14:29 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-/* Prints the specified array of strings, separated by newlines */
-int	ft_printarr(char **tab)
+void	ft_putunbr_base_fd(long int number, int fd, char *base, int base_len)
 {
-	int	i;
-
-	i = 0;
-	while (tab[i])
+	if (fd >= 0)
 	{
-		ft_putstr_fd(tab[i], 1);
-		if (tab[i + 1])
-			ft_putstr_fd(", ", 1);
-		i++;
+		if (number >= base_len)
+			ft_putunbr_base_fd((number / base_len), fd, base, base_len);
+		ft_putchar_fd(*(base + (number % base_len)), fd);
 	}
-	ft_putchar_fd('\n', 1);
-	return (0);
 }

--- a/sources/utils/ft_putnbr_fd.c
+++ b/sources/utils/ft_putnbr_fd.c
@@ -1,30 +1,24 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   ft_printarr.c                                      :+:      :+:    :+:   */
+/*   ft_putnbr_fd.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2024/04/03 20:06:36 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/29 12:47:39 by mdanish          ###   ########.fr       */
+/*   Created: 2023/07/16 15:21:30 by mdanish           #+#    #+#             */
+/*   Updated: 2024/05/29 12:14:29 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-/* Prints the specified array of strings, separated by newlines */
-int	ft_printarr(char **tab)
+void	ft_putnbr_fd(long int number, int fd)
 {
-	int	i;
-
-	i = 0;
-	while (tab[i])
+	if (fd >= 0)
 	{
-		ft_putstr_fd(tab[i], 1);
-		if (tab[i + 1])
-			ft_putstr_fd(", ", 1);
-		i++;
+		if (number > -1)
+			return (ft_putunbr_base_fd(number, fd, DECIMAL, 10));
+		ft_putchar_fd('-', fd);
+		return (ft_putunbr_base_fd(number * -1, fd, DECIMAL, 10));
 	}
-	ft_putchar_fd('\n', 1);
-	return (0);
 }

--- a/sources/utils/ft_putstr_fd.c
+++ b/sources/utils/ft_putstr_fd.c
@@ -1,30 +1,19 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   ft_printarr.c                                      :+:      :+:    :+:   */
+/*   ft_putstr_fd.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2024/04/03 20:06:36 by maabdull          #+#    #+#             */
-/*   Updated: 2024/05/29 12:47:39 by mdanish          ###   ########.fr       */
+/*   Created: 2023/07/16 14:46:44 by mdanish           #+#    #+#             */
+/*   Updated: 2024/05/29 12:14:29 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-/* Prints the specified array of strings, separated by newlines */
-int	ft_printarr(char **tab)
+void	ft_putstr_fd(char *string, int fd)
 {
-	int	i;
-
-	i = 0;
-	while (tab[i])
-	{
-		ft_putstr_fd(tab[i], 1);
-		if (tab[i + 1])
-			ft_putstr_fd(", ", 1);
-		i++;
-	}
-	ft_putchar_fd('\n', 1);
-	return (0);
+	if (fd >= 0)
+		write(fd, string, ft_strlen(string));
 }

--- a/sources/utils/module.mk
+++ b/sources/utils/module.mk
@@ -1,4 +1,7 @@
-UTILS_SRCS := $(addprefix $(UTILS_DIR)/, ft_join.c ft_lstadd_back.c ft_printarr.c ft_memset.c\
-	      ft_split.c ft_strchr.c ft_strcpy.c ft_strjoin.c ft_strlen.c \
-	      ft_strncmp.c ft_substr.c ft_free_2d_arr.c ft_strlcpy.c ft_strdup.c ft_char_strjoin.c ft_is_quotation.c ft_isspace.c)
+UTILS_SRCS := $(addprefix $(UTILS_DIR)/, ft_char_strjoin.c ft_free_2d_arr.c \
+			ft_is_quotation.c ft_isspace.c ft_join.c ft_lstadd_back.c \
+			ft_memset.c ft_printarr.c ft_putchar_fd.c ft_putendl_fd.c \
+			ft_putnbr_base_fd.c ft_putnbr_fd.c ft_putstr_fd.c ft_split.c \
+			ft_strchr.c ft_strcpy.c ft_strdup.c ft_strjoin.c ft_strlcpy.c \
+			ft_strlen.c ft_strncmp.c ft_substr.c)
 SRCS += $(UTILS_SRCS)


### PR DESCRIPTION
The `export` builtin is complete in all of its
functionality. When run without arguments, it will
print the list of environment variables in
alphabetical order. When run with arguments, it
will go through them to ensure validity and assign
the new variables to the `list` as well as the
`matrix` according to the behavior of the original
`export` builtin.

An empty value will not update the `matrix`. An
existing `key` without a `value` does nothing where
an existing `key` with a `value` is updated in the
`matrix` as well as `list`. A new `key` with no `value`
is added to the `matrix` and the `list`, and will display
the `key` correctly when prompted. A new `key` with
`value` is added to the `matrix` and the `list`.