### PR TITLE
feat: wildcards now expand to the files in the cwd

### DIFF
--- a/includes/libft.h
+++ b/includes/libft.h
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/13 15:29:04 by mdanish           #+#    #+#             */
-/*   Updated: 2024/06/10 18:18:25 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/06/20 17:15:58 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,7 @@
 # define HEX_UP "0123456789ABCDEF"
 # define DECIMAL "0123456789"
 
+char	*ft_c_strjoin_free(char *s1, char *s2, char c, int free_string);
 char	*ft_char_strjoin(char const *s1, char const *s2, char const c);
 void	ft_free_2d_arr(char **arr);
 char	ft_is_quotation(char c);
@@ -42,6 +43,7 @@ char	**ft_split(char const *s, char c);
 char	*ft_strchr(const char *s, int c);
 void	ft_strcpy(char *dest, char const *src);
 char	*ft_strdup(const char *src);
+char	*ft_strjoin_free(char *s1, char *s2, int free_string);
 char	*ft_strjoin(char const *s1, char const *s2);
 size_t	ft_strlcpy(char *dst, const char *src, size_t dstsize);
 size_t	ft_strlen(const char *str);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 17:24:25 by maabdull          #+#    #+#             */
-/*   Updated: 2024/06/10 15:17:07 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/06/20 23:37:30 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,12 +20,15 @@
 # define B_YELLOW "\033[33;1m"
 # define RESET "\033[0m"
 
+# include <dirent.h>
+# include <errno.h>
 # include "libft.h"
 # include <readline/history.h>
 # include <readline/readline.h>
 # include <signal.h>
 # include <stdbool.h>
 # include <string.h>
+# include <sys/types.h>
 # include <sys/wait.h>
 # include <termios.h>
 # include <time.h>
@@ -35,6 +38,7 @@ extern int					g_status_code;
 
 /** STRUCTURES **/
 typedef enum e_token_types	t_type;
+typedef struct dirent		t_dir;
 typedef struct s_cmd		t_cmd;
 typedef struct s_cmd_exec	t_cmd_exec;
 typedef struct s_env		t_env;
@@ -104,6 +108,7 @@ struct s_cmd_exec
 char		*dollar_expansion(char *token, t_env *list);
 t_cmd		*create_exec_cmd(t_minishell *minishell);
 void		parse(t_minishell *minishell, char *line);
+char		*wildcards(char *token, char *store);
 
 // Execution
 void		exec_builtin(char **cmd, t_minishell *minishell);

--- a/sources/parsing/dollar.c
+++ b/sources/parsing/dollar.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/10 17:04:29 by mdanish           #+#    #+#             */
-/*   Updated: 2024/06/10 22:38:41 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/06/21 02:28:35 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -156,19 +156,16 @@ static void	replace_status_code(char **token, int start, int end, int length)
  */
 static bool	invalid_key(char **token, int *start, int *end, int length)
 {
-	while (token[0][++(*start)])
+	while (token[0][(*start)++])
 	{
-		if (token[0][*start - 1] == '\'')
-		{
-			(*start)++;
-			while (token[0][*start - 1] != '\'')
-				(*start)++;
+		if (ft_is_quotation(token[0][*start - 1]) == '\'')
 			continue ;
-		}
-		if (token[0][*start - 1] == '$')
+		else if (token[0][*start - 1] == '$')
+			break ;
+		if (!token[0][*start - 1])
 			break ;
 	}
-	if (!token[0][*start - 1])
+	if (!token[0][*start - 1] && (*start)--)
 		return (true);
 	*end = *start;
 	if (token[0][*end] == '?')
@@ -184,7 +181,7 @@ static bool	invalid_key(char **token, int *start, int *end, int length)
 }
 
 /**
- * @brief Expands any dollar sign if found.
+ * @brief Expands any and all dollar signs if found.
  * 
  * The function uses invalid_key() to identify if the token contains any valid
  * keys. This function will also store the index at which the key starts and

--- a/sources/parsing/module.mk
+++ b/sources/parsing/module.mk
@@ -1,2 +1,3 @@
-PARSER_SRCS := $(addprefix $(PARSER_DIR)/, create_cmd.c dollar.c parser.c)
+PARSER_SRCS := $(addprefix $(PARSER_DIR)/, create_cmd.c dollar.c parser.c \
+				wildcard.c)
 SRCS += $(PARSER_SRCS)

--- a/sources/parsing/parser.c
+++ b/sources/parsing/parser.c
@@ -6,7 +6,7 @@
 /*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/04 14:41:15 by maabdull          #+#    #+#             */
-/*   Updated: 2024/06/10 17:06:18 by mdanish          ###   ########.fr       */
+/*   Updated: 2024/06/20 23:37:19 by mdanish          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -232,8 +232,11 @@ t_token	*tokenize(t_minishell *minishell, char *input)
 		tokens[i].content = get_token(&input);
 		tokens[i].type = get_token_type(tokens[i].content);
 		if (tokens[i].type == WORD)
+		{
 			tokens[i].content = dollar_expansion(tokens[i].content, \
 			minishell->env_variables);
+			tokens[i].content = wildcards(tokens[i].content, tokens[i].content);
+		}
 		i++;
 	}
 	tokens[i].content = NULL;

--- a/sources/parsing/wildcard.c
+++ b/sources/parsing/wildcard.c
@@ -1,0 +1,217 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   wildcard.c                                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/06/12 18:51:40 by mdanish           #+#    #+#             */
+/*   Updated: 2024/06/21 01:55:39 by mdanish          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+/**
+ * @brief Searches for a wildcard.
+ * 
+ * The function goes through the token character by character to check if a
+ * [ * ] is present. It ensures that the [ * ] enclosed within quotation is
+ * ignored. Upon identification of the [ * ], the opendir() function is used to
+ * open the current directory. It uses the return of getcwd() as its argument.
+ * This only happens in the first call to this function.
+ * 
+ * @param token is the token that needs to be checked for the wildcard.
+ * @param location will contain the location of the identified wildcard.
+ * @param cwd points to the variable which will store the directory stream.
+ * 
+ * @return true when a [ * ] is found, false if no [ * ] or opendir() failed.
+ */
+static bool	wildcards_are_present(char *token, int *location, DIR **cwd)
+{
+	char	cwd_path[PATH_MAX];
+
+	*location = -1;
+	while (token[++*location])
+	{
+		if (ft_is_quotation(token[*location]))
+			continue ;
+		else if (token[*location] == '*')
+			break ;
+	}
+	if (cwd && token[*location] == '*')
+	{
+		*cwd = opendir(getcwd(cwd_path, PATH_MAX));
+		if (*cwd)
+		{
+			errno = 0;
+			return (true);
+		}
+		ft_putendl_fd("Directory can not be opened", 2);
+	}
+	return (false);
+}
+
+/**
+ * @brief Checks if expansion needs to include hidden files.
+ * 
+ * The function simply checks through a bunch of hard-coded cases to check if
+ * any of the hidden files (files that begin with a [ . ]) are required to be
+ * included in the expansion.
+ * 
+ * @param token will be checked to see if hidden files are needed.
+ * @param location of the [ * ] in the token.
+ * 
+ * @return true if hidden files are to be included, false if otherwise.
+ */
+static bool	require_hidden_file(char *token, int location)
+{
+	if (location == 1 && token[0] == '.')
+		return (true);
+	if (location == 3 && token[1] == '.')
+	{
+		if (token[0] == '\'' && token[2] == '\'')
+			return (true);
+		if (token[0] == '"' && token[2] == '"')
+			return (true);
+	}
+	if (location == 2 && token[0] == '.' && token[1] == '.')
+		return (true);
+	if (location == 4 && token[1] == '.' && token[2] == '.')
+	{
+		if (token[0] == '\'' && token[3] == '\'')
+			return (true);
+		if (token[0] == '"' && token[3] == '"')
+			return (true);
+	}
+	return (false);
+}
+
+/**
+ * @brief Compares the leading characters of the filename with the token.
+ * 
+ * The function goes through the token and matches them to the filename till
+ * either the wildcard's location is reached or a non-matching character is
+ * found. This also ensures it is done before the wildcard is reached.
+ * 
+ * It ensures that all quotes that are meant to be omitted are not included in
+ * the matching of the token and filename.
+ * 
+ * @param token will be compared with the file.
+ * @param file is the name of the file in the directory.
+ * @param t_index points to the index of the token.
+ * @param location is the index of the token at which the wildcard exists.
+ * 
+ * @return The index of the file at the end, or -1 in case of mismatch.
+ */
+static int	compare_names(char *token, char *file, int *t_index, int location)
+{
+	char	quote;
+	int		f_index;
+
+	quote = '\0';
+	f_index = 0;
+	while (token[++*t_index] && *t_index != location)
+	{
+		if (!quote && (token[*t_index] == '"' || token[*t_index] == '\''))
+			quote = token[*t_index];
+		else if (quote && token[*t_index] == quote)
+			quote = '\0';
+		else if (token[*t_index] != file[f_index++])
+			return (-1);
+	}
+	return (f_index);
+}
+
+/**
+ * @brief Checks if the file name matches with the token.
+ * 
+ * The function ensures that hidden files are needed by running the
+ * require_hidden_file() function. It then sends it to compare_names() to check
+ * if the file name matches the token. If it does match, it continues to set up
+ * the next check by increasing the token's index and file's index as necessary.
+ * 
+ * To check is there are more [ * ] in the token, wildcards_are_present() is
+ * called again. If the location points to a null byte, the evaluated return of
+ * the ft_strncmp() function is returned from the function. If the location ends
+ * up pointing to a [ * ], the a recursive call to match_pattern() is returned.
+ * 
+ * @param token will be used to see if the file is to be expanded to.
+ * @param location contains the index of the [ * ] in the token.
+ * @param file is the file name with will be matched with the token.
+ * 
+ * @return true if file matches the pattern, false if file doesn't.
+ */
+static bool	match_pattern(char *token, int location, char *file)
+{
+	int		f_index;
+	int		t_index;
+
+	if (file[0] == '.' && !require_hidden_file(token, location))
+		return (false);
+	t_index = -1;
+	f_index = compare_names(token, file, &t_index, location);
+	if (t_index != location || f_index < 0)
+		return (false);
+	while (token[t_index] == '*')
+		t_index++;
+	if (!token[t_index])
+		return (true);
+	while ((f_index || !location) && file[f_index] && \
+		token[t_index] != file[f_index])
+		f_index++;
+	if (!file[f_index])
+		return (false);
+	wildcards_are_present(token + t_index, &location, NULL);
+	if (!token[t_index + location])
+		return (!ft_strncmp(token + t_index, file + f_index, location + 1));
+	return (match_pattern(token + t_index, location, file + f_index));
+}
+
+/**
+ * @brief Expands any and all wildcards if found.
+ * 
+ * The function uses wildcards_are_present() to identify if the token contains
+ * any wildcards. This function will also store the index at which the wildcard
+ * is at by updating the variable which will be sent to it. In the case that
+ * there is no wildcard, the original token is returned.
+ * 
+ * The readdir() function returns information about the files present in the
+ * current directory. This is sent to match_pattern() to validate the file name
+ * according to the pattern provided by the token.
+ * 
+ * For each valid filename, it is joined and stored in the token variable, which
+ * is returned upon success.
+ * 
+ * @param token is the token that needs to be checked for the wildcards.
+ * @param store contains a copy of token.
+ * 
+ * @return the pointer to the final token.
+ */
+char	*wildcards(char *token, char *store)
+{
+	DIR		*cwd_stream;
+	t_dir	*files;
+	int		location;
+
+	if (!wildcards_are_present(token, &location, &cwd_stream))
+		return (token);
+	token = NULL;
+	files = readdir(cwd_stream);
+	while (files)
+	{
+		if (match_pattern(store, location, files->d_name))
+		{
+			token = ft_c_strjoin_free(files->d_name, token, ' ', 2);
+			if (!token)
+				break ;
+		}
+		files = readdir(cwd_stream);
+	}
+	closedir(cwd_stream);
+	if (errno)
+		ft_putendl_fd("Directory can not be read", 2);
+	else if (!errno && token)
+		return (token);
+	return (store);
+}

--- a/sources/utils/ft_strjoin_free.c
+++ b/sources/utils/ft_strjoin_free.c
@@ -1,0 +1,49 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_strjoin_free.c                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: mdanish <mdanish@student.42abudhabi.ae>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/06/20 17:06:47 by mdanish           #+#    #+#             */
+/*   Updated: 2024/06/21 01:57:44 by mdanish          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+char	*ft_strjoin_free(char *s1, char *s2, int free_string)
+{
+	char	*final_string;
+
+	if (!s1 && !s2)
+		return (NULL);
+	if (!s1)
+		final_string = ft_strjoin("", s2);
+	if (!s2)
+		final_string = ft_strjoin(s1, "");
+	if (free_string == 1 || free_string == 3)
+		free(s1);
+	if (free_string == 2 || free_string == 3)
+		free(s2);
+	return (final_string);
+}
+
+char	*ft_c_strjoin_free(char *s1, char *s2, char c, int free_string)
+{
+	char	*final_string;
+
+	if (!s1 && !s2)
+		return (ft_strdup(&c));
+	if (!s1)
+		final_string = ft_strdup(s2);
+	else if (!s2)
+		final_string = ft_strdup(s1);
+	else
+		final_string = ft_char_strjoin(s1, s2, c);
+	if (free_string == 1 || free_string == 3)
+		free(s1);
+	if (free_string == 2 || free_string == 3)
+		free(s2);
+	return (final_string);
+}

--- a/sources/utils/module.mk
+++ b/sources/utils/module.mk
@@ -3,6 +3,6 @@ UTILS_SRCS := $(addprefix $(UTILS_DIR)/, ft_char_strjoin.c ft_free_2d_arr.c \
 			ft_isspace.c ft_join.c ft_lstadd_back.c ft_memcpy.c ft_memset.c \
 			ft_printarr.c ft_putchar_fd.c ft_putendl_fd.c ft_putnbr_base_fd.c \
 			ft_putnbr_fd.c ft_putstr_fd.c ft_split.c ft_strchr.c ft_strcpy.c \
-			ft_strdup.c ft_strjoin.c ft_strlcpy.c ft_strlen.c ft_strncmp.c \
-			ft_substr.c)
+			ft_strdup.c ft_strjoin.c ft_strjoin_free.c ft_strlcpy.c ft_strlen.c\
+			ft_strncmp.c ft_substr.c)
 SRCS += $(UTILS_SRCS)


### PR DESCRIPTION
For every token of type WORD, I check for a [ * ]. 
Three system calls are used mainly to identify and
match file names with the token. It ensures that
the hidden files are ignored unless specified.

To achieve the complex pattern matching, I
recursively call the function responsible for it
with updated arguments, so that it essentially
matches the leading characters. If the pattern
needs a comparison of the trailing chararacters,
I use the ft_strncmp() function for that match.

While testing, I came across a bug in the dollar
expansion section. The expansion would ignoring
everything after a [ ' ] regardless of it being
nested within [ " " ] or whether or not there was
a closing [ ' ]. This is now rectified.